### PR TITLE
記事詳細にマップを追加

### DIFF
--- a/app/javascript/pages/article/components/index/ArticleItem.vue
+++ b/app/javascript/pages/article/components/index/ArticleItem.vue
@@ -1,60 +1,103 @@
 <template>
-  <div class="col-12">
-    <div class="card article-border">
-      <div class="card-body pt-1 pb-2">
-        <div class="d-flex align-items-center pb-1">
+  <div>
+    <template v-if="$mq == 'xs'">
+      <div class="row mt-4 bg-white article-xs">
+        <div class="col-12">
+          <router-link :to="{ name: 'ArticleShow', query: {id: article.id} }">
+            <div class="row pt-3 pl-3 pr-3">
+              <h4 class="col-12 m-0 pt-1 pb-1 text-center text-white font-weight-bold article-title word-break">
+                {{ article.title }}
+              </h4>
+              <template v-if="article.description">
+                <p class="col-12 mt-3 mb-0 p-2 d-flex justify-content-center bg-light text-dark article-description word-break">
+                  {{ article.description }}
+                </p>
+              </template>
+              <p class="col-12 m-0 pt-1 pb-1 text-center text-muted article-info word-break">
+                {{ article.region.name }}&nbsp;
+                日程：{{ article.start_date | moment('M/D(ddd)') }}〜{{ article.end_date | moment('M/D(ddd)') }}
+              </p>
+            </div>
+          </router-link>
+        </div>
+        <div class="col-12">
           <img
             src="../../../../images/sample.png"
-            class="user-icon"
+            class="main-image m-0 pt-3 pb-3"
           >
-          <h5 class="card-title d-inline mb-0 pl-2 word-break">
-            Manabu Ito
-          </h5>
-          <p class="text-muted mb-0 pt-4 article-date">
-            {{ article.created_at | moment('M/D HH:mm') }}
-          </p>
         </div>
-        <router-link :to="{ name: 'ArticleShow', query: {id: article.id} }">
-          <div class="article-main">
-            <h4 class="card-title m-2 article-title word-break">
-              {{ article.title }}
-            </h4>
-            <div class="row">
-              <div class="col-sm-8">
+        <div class="col-12">
+          <div class="pt-1 pb-1 d-flex justify-content-center align-items-center">
+            <img
+              src="../../../../images/sample.png"
+              class="user-icon"
+            >
+            <h5 class="float-right mb-0 pl-3 word-break">
+              Ito Manabua
+            </h5>
+            <div class="text-center pl-3">
+              <font-awesome-icon
+                :icon="['far', 'thumbs-up']"
+                class="fa-lg"
+              />
+              <p class="m-0 word-break">
+                100
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+    <template v-else>
+      <div class="pl-3 pr-3">
+        <div class="row mt-4 bg-white article">
+          <div class="col-12">
+            <router-link :to="{ name: 'ArticleShow', query: {id: article.id} }">
+              <div class="row pt-3 pl-3 pr-3 ">
+                <h4 class="col-12 m-0 pt-1 pb-1 text-center text-white font-weight-bold article-title word-break">
+                  {{ article.title }}
+                </h4>
                 <template v-if="article.description">
-                  <p class="card-body bg-light mb-0 p-2 article-border word-break">
+                  <p class="col-12 mt-3 mb-0 p-2 d-flex justify-content-center bg-light text-dark article-description word-break">
                     {{ article.description }}
                   </p>
                 </template>
-                <div class="text-muted m-2 article-info word-break">
-                  <p class="d-inline">
-                    {{ article.region.name }}
-                  </p>
-                  <p class="d-inline ml-2">
-                    日程：{{ article.start_date | moment('M/D(ddd)') }}〜{{ article.end_date | moment('M/D(ddd)') }}
-                  </p>
-                </div>
+                <p class="col-12 m-0 pt-1 pb-1 text-center text-muted article-info word-break">
+                  {{ article.region.name }}&nbsp;
+                  日程：{{ article.start_date | moment('M/D(ddd)') }}〜{{ article.end_date | moment('M/D(ddd)') }}
+                </p>
               </div>
-              <div class="col-sm-4">
-                <img
-                  src="../../../../images/sample.png"
-                  class="main-image"
-                >
+            </router-link>
+          </div>
+          <div class="col-12">
+            <img
+              src="../../../../images/sample.png"
+              class="main-image m-0 pt-3 pb-3"
+            >
+          </div>
+          <div class="col-12">
+            <div class="pt-1 pb-1 d-flex justify-content-center align-items-center">
+              <img
+                src="../../../../images/sample.png"
+                class="user-icon"
+              >
+              <h5 class="float-right mb-0 pl-3 word-break">
+                Ito Manabua
+              </h5>
+              <div class="text-center pl-3">
+                <font-awesome-icon
+                  :icon="['far', 'thumbs-up']"
+                  class="fa-lg"
+                />
+                <p class="m-0 word-break">
+                  100
+                </p>
               </div>
             </div>
           </div>
-        </router-link>
-        <div class="pt-2 pr-2 text-right">
-          <font-awesome-icon
-            :icon="['far', 'thumbs-up']"
-            class="fa-lg"
-          />
-          <p class="d-inline">
-            100
-          </p>
         </div>
       </div>
-    </div>
+    </template>
   </div>
 </template>
 
@@ -73,39 +116,33 @@ export default {
 </script>
 
 <style scoped>
-.container-fluid {
-  margin-right: auto;
-  margin-left: auto;
-  max-width: 700px;
-}
-
 .word-break {
   word-break: break-word;
 }
-.user-icon {
-  width: 40px;
-	height: 40px;
-	object-fit: cover;
-	border-radius: 50%;
+
+.article {
+  border: solid #FF00EB;
+  border-radius: 6px;
 }
 
-.article-main {
-  border-top: solid thin #FF00EB;
-  border-bottom: solid thin #FF00EB;
-  cursor: pointer;
+.article-xs {
+  border-top: solid thin #CBCBCB;
+  border-bottom: solid thin #CBCBCB;
 }
 
 .article-title {
-  font-weight: bold;
+  background-color: #FF00EB;
+  border-radius: 6px;
 }
 
-.article-border {
+.article-description {
   border: solid thin #FF00EB;
   border-radius: 6px;
 }
 
 .article-info {
   font-size: 14px;
+  border-bottom: solid thin #FF00EB;
 }
 
 .article-date {
@@ -115,6 +152,13 @@ export default {
 
 .main-image {
   width: 100%;
-  margin-bottom: 15px;
+  border-bottom: solid thin #FF00EB;
+}
+
+.user-icon {
+  width: 40px;
+	height: 40px;
+	object-fit: cover;
+	border-radius: 50%;
 }
 </style>

--- a/app/javascript/pages/article/components/index/ArticleList.vue
+++ b/app/javascript/pages/article/components/index/ArticleList.vue
@@ -1,13 +1,15 @@
 <template>
-  <div class="container-fluid mt-4">
+  <div>
     <div
       v-for="article in articles"
       :key="article.id"
-      class="row mt-3"
+      class="row"
     >
-      <ArticleItem
-        :article="article"
-      />
+      <div class="col-12">
+        <ArticleItem
+          :article="article"
+        />
+      </div>
     </div>
   </div>
 </template>
@@ -30,9 +32,4 @@ export default {
 </script>
 
 <style scoped>
-.container-fluid {
-  margin-right: auto;
-  margin-left: auto;
-  max-width: 800px;
-}
 </style>

--- a/app/javascript/pages/article/components/index/SearchColumn.vue
+++ b/app/javascript/pages/article/components/index/SearchColumn.vue
@@ -1,0 +1,142 @@
+<template>
+  <div>
+    <template v-if="$mq == 'sm'">
+      <div class="pl-3 pr-3 mt-4 ml-sm-5 mr-sm-5 pl-sm-5 pr-sm-5">
+        <div class="row bg-white search">
+          <h4 class="col-12 mb-1 p-2 text-center text-white font-weight-bold article-title word-break">
+            hello
+          </h4>
+          <p class="col-12 text-muted text-center word-break article-info">
+            hello
+          </p>
+          <div class="col-12 p-0 mb-3">
+            <p class="text-center text-white m-0 description-label">
+              概要
+            </p>
+            <p class="text-dark bg-white p-2 m-0 word-break description-main">
+              hello
+            </p>
+          </div>
+          <div class="col-12 d-flex justify-content-center align-items-center user-name">
+            <img
+              src="../../../../images/sample.png"
+              class="user-icon"
+            >
+            <h4 class="float-right mb-0 pl-2 word-break">
+              Ito Manabu
+            </h4>
+            <div class="text-center pl-4">
+              <font-awesome-icon
+                :icon="['far', 'thumbs-up']"
+                class="fa-lg"
+              />
+              <p class="m-0 word-break">
+                100
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+    <template v-else>
+      <div class="sidebar_fixed mt-4 pl-3 pr-3">
+        <div class="row bg-white search">
+          <h4 class="col-12 mb-1 p-2 text-center text-white font-weight-bold article-title word-break">
+            hello
+          </h4>
+          <p class="col-12 text-muted text-center word-break article-info">
+            hello
+          </p>
+          <div class="col-12 p-0 mb-3">
+            <p class="text-center text-white m-0 description-label">
+              概要
+            </p>
+            <p class="text-dark bg-white p-2 m-0 word-break description-main">
+              hello
+            </p>
+          </div>
+          <div class="col-12 d-flex justify-content-center align-items-center user-name">
+            <img
+              src="../../../../images/sample.png"
+              class="user-icon"
+            >
+            <h4 class="float-right mb-0 pl-2 word-break">
+              Ito Manabu
+            </h4>
+            <div class="text-center pl-4">
+              <font-awesome-icon
+                :icon="['far', 'thumbs-up']"
+                class="fa-lg"
+              />
+              <p class="m-0 word-break">
+                100
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'SearchColumn',
+  props: {
+    article: {
+      type: Object,
+      required: true
+    }
+  }
+}
+</script>
+
+<style scoped>
+.word-break {
+  word-break: break-word;
+}
+
+.sidebar_fixed {
+  position: sticky;
+  top: 60px;
+}
+
+.search {
+  border: solid #CBCBCB;
+  border-radius: 6px;
+}
+
+.article-title {
+  background-color: #6A6A6A;
+  border: solid thin #6A6A6A;
+  border-radius: 6px;
+}
+
+.user-name {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.user-icon {
+  width: 40px;
+	height: 40px;
+	object-fit: cover;
+	border-radius: 50%;
+}
+
+.description-label {
+  background-color: #6A6A6A;
+  border-radius: 6px 6px 0px 0px / 6px 6px 0px 0px;
+}
+
+.description-main {
+  font-size: 14px;
+  border: solid thin #6A6A6A;
+  border-radius: 0px 0px 6px 6px / 0px 0px 6px 6px;
+  border-width: 0px 0.1px 0.1px 0.1px;
+}
+
+.article-info {
+  font-size: 13px;
+}
+</style>

--- a/app/javascript/pages/article/components/show/CostColumn.vue
+++ b/app/javascript/pages/article/components/show/CostColumn.vue
@@ -1,247 +1,73 @@
 <template>
-  <div>
-    <!-- <template v-if="$mq == 'sm'"> -->
+  <div class="mb-4">
     <div class="d-flex justify-content-center">
       <div class="pt-3 pr-3 pl-3 bg-white cost-column">
-        <template v-if="tourings.length">
-          <div class="mb-3">
-            <p class="mb-0 text-center text-white content-label">
-              観光費
-            </p>
-            <div
-              v-for="touring in tourings"
-              :key="touring.id"
-            >
-              <div class="row mt-2 ml-2 mr-2 cost-border">
-                <div class="col-8 p-0">
-                  <p class="m-0 word-break">
-                    {{ touring.description }}
-                  </p>
-                </div>
-                <div class="col-4 p-0 text-right">
-                  <p class="m-0">
-                    {{ separateWithComma(touring.cost) }}円
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div class="row mt-2 ml-2 mr-2 cost-border">
-              <div class="col-12 p-0 text-right">
-                <p class="m-0 font-weight-bold">
-                  合計：&nbsp;&nbsp;{{ separateWithComma(totalTouringCost) }}円
-                </p>
-              </div>
-            </div>
-          </div>
-        </template>
-        <template v-if="activities.length">
-          <div class="mb-3">
-            <p class="mb-0 text-center text-white content-label">
-              アクティビティ費
-            </p>
-            <div
-              v-for="activity in activities"
-              :key="activity.id"
-            >
-              <div class="row mt-2 ml-2 mr-2 cost-border">
-                <div class="col-8 p-0">
-                  <p class="m-0 word-break">
-                    {{ activity.description }}
-                  </p>
-                </div>
-                <div class="col-4 p-0 text-right">
-                  <p class="m-0">
-                    {{ separateWithComma(activity.cost) }}円
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div class="row mt-2 ml-2 mr-2 cost-border">
-              <div class="col-12 p-0 text-right">
-                <p class="m-0 font-weight-bold">
-                  合計：&nbsp;&nbsp;{{ separateWithComma(totalActivityCost) }}円
-                </p>
-              </div>
-            </div>
-          </div>
-        </template>
-        <template v-if="foods.length">
-          <div class="mb-3">
-            <p class="mb-0 text-center text-white content-label">
-              食費
-            </p>
-            <div
-              v-for="food in foods"
-              :key="food.id"
-            >
-              <div class="row mt-2 ml-2 mr-2 cost-border">
-                <div class="col-8 p-0">
-                  <p class="m-0 word-break">
-                    {{ food.description }}
-                  </p>
-                </div>
-                <div class="col-4 p-0 text-right">
-                  <p class="m-0">
-                    {{ separateWithComma(food.cost) }}円
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div class="row mt-2 ml-2 mr-2 cost-border">
-              <div class="col-12 p-0 text-right">
-                <p class="m-0 font-weight-bold">
-                  合計：&nbsp;&nbsp;{{ separateWithComma(totalFoodCost) }}円
-                </p>
-              </div>
-            </div>
-          </div>
-        </template>
-        <template v-if="souvenirs.length">
-          <div class="mb-3">
-            <p class="mb-0 text-center text-white content-label">
-              お土産代
-            </p>
-            <div
-              v-for="souvenir in souvenirs"
-              :key="souvenir.id"
-            >
-              <div class="row mt-2 ml-2 mr-2 cost-border">
-                <div class="col-8 p-0">
-                  <p class="m-0 word-break">
-                    {{ souvenir.description }}
-                  </p>
-                </div>
-                <div class="col-4 p-0 text-right">
-                  <p class="m-0">
-                    {{ separateWithComma(souvenir.cost) }}円
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div class="row mt-2 ml-2 mr-2 cost-border">
-              <div class="col-12 p-0 text-right">
-                <p class="m-0 font-weight-bold">
-                  合計：&nbsp;&nbsp;{{ separateWithComma(totalSouvenirCost) }}円
-                </p>
-              </div>
-            </div>
-          </div>
-        </template>
-        <template v-if="accommodations.length">
-          <div class="mb-3">
-            <p class="mb-0 text-center text-white content-label">
-              宿泊費
-            </p>
-            <div
-              v-for="accommodation in accommodations"
-              :key="accommodation.id"
-            >
-              <div class="row mt-2 ml-2 mr-2 cost-border">
-                <div class="col-8 p-0">
-                  <p class="m-0 word-break">
-                    {{ accommodation.description }}
-                  </p>
-                </div>
-                <div class="col-4 p-0 text-right">
-                  <p class="m-0">
-                    {{ separateWithComma(accommodation.cost) }}円
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div class="row mt-2 ml-2 mr-2 cost-border">
-              <div class="col-12 p-0 text-right">
-                <p class="m-0 font-weight-bold">
-                  合計：&nbsp;&nbsp;{{ separateWithComma(totalAccommodationCost) }}円
-                </p>
-              </div>
-            </div>
-          </div>
-        </template>
-        <template v-if="transportations.length">
-          <div class="mb-3">
-            <p class="mb-0 text-center text-white content-label">
-              交通費
-            </p>
-            <div
-              v-for="transportation in transportations"
-              :key="transportation.id"
-            >
-              <template v-if="transportation.cost != null">
-                <div class="row mt-2 ml-2 mr-2 cost-border">
-                  <div class="col-8 p-0">
-                    <p class="m-0 word-break">
-                      <template v-if="transportation.description">
-                        {{ transportation.description }}
-                      </template>
-                      <template v-else>
-                        {{ defaultTransportation(transportation.means) }}
-                      </template>
-                    </p>
+        <div
+          v-for="costByGenre in costs"
+          :key="costByGenre[0]"
+        >
+          <div v-if="costByGenre[1].length">
+            <div class="mb-3">
+              <p class="mb-0 text-center text-white content-label">
+                {{ labelOrCost(costByGenre[1][0].genre).label }}
+              </p>
+              <div
+                v-for="costInfo in costByGenre[1]"
+                :key="costInfo.id"
+              >
+                <template v-if="costInfo.means">
+                  <template v-if="costInfo.cost">
+                    <div class="row mt-2 ml-2 mr-2 cost-border">
+                      <div class="col-8 p-0">
+                        <p class="m-0 word-break">
+                          <template v-if="costInfo.description">
+                            {{ costInfo.description }}
+                          </template>
+                          <template v-else>
+                            {{ defaultTransportationDescription(costInfo.means) }}
+                          </template>
+                        </p>
+                      </div>
+                      <div class="col-4 p-0 text-right">
+                        <p class="m-0">
+                          {{ separateWithComma(costInfo.cost) }}円
+                        </p>
+                      </div>
+                    </div>
+                  </template>
+                </template>
+                <template v-else>
+                  <div class="row mt-2 ml-2 mr-2 cost-border">
+                    <div class="col-8 p-0">
+                      <p class="m-0 word-break">
+                        {{ costInfo.description }}
+                      </p>
+                    </div>
+                    <div class="col-4 p-0 text-right">
+                      <p class="m-0">
+                        {{ separateWithComma(costInfo.cost) }}円
+                      </p>
+                    </div>
                   </div>
-                  <div class="col-4 p-0 text-right">
-                    <p class="m-0">
-                      {{ separateWithComma(transportation.cost) }}円
-                    </p>
-                  </div>
-                </div>
-              </template>
-            </div>
-            <div class="row mt-2 ml-2 mr-2 cost-border">
-              <div class="col-12 p-0 text-right">
-                <p class="m-0 font-weight-bold">
-                  合計：&nbsp;&nbsp;{{ separateWithComma(totalTransportationCost) }}円
-                </p>
+                </template>
               </div>
-            </div>
-          </div>
-        </template>
-        <template v-if="others.length">
-          <div class="mb-3">
-            <p class="mb-0 text-center text-white content-label">
-              その他
-            </p>
-            <div
-              v-for="other in others"
-              :key="other.id"
-            >
               <div class="row mt-2 ml-2 mr-2 cost-border">
-                <div class="col-8 p-0">
-                  <p class="m-0 word-break">
-                    {{ other.description }}
+                <div class="col-12 p-0 text-right">
+                  <p class="m-0 font-weight-bold">
+                    合計：&nbsp;&nbsp;{{ labelOrCost(costByGenre[1][0].genre).cost }}円
                   </p>
                 </div>
-                <div class="col-4 p-0 text-right">
-                  <p class="m-0">
-                    {{ separateWithComma(other.cost) }}円
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div class="row mt-2 ml-2 mr-2 cost-border">
-              <div class="col-12 p-0 text-right">
-                <p class="m-0 font-weight-bold">
-                  合計：&nbsp;&nbsp;{{ separateWithComma(totalOtherCost) }}円
-                </p>
               </div>
             </div>
           </div>
-        </template>
+        </div>
         <div class="mt-5 mb-5 ml-2 mr-2 text-center">
-          <h4 class="d-inline font-weight-bold toatal-cost-border">
-            総コスト：&nbsp;{{ separateWithComma(totalCost) }}円
+          <h4 class="d-inline text-dark font-weight-bold toatal-cost-border">
+            総計：&nbsp;{{ separateWithComma(totalCost) }}円
           </h4>
         </div>
       </div>
     </div>
-    <!-- </template>
-    <template v-else>
-      <div class="row sidebar_fixed pl-3 pr-3">
-        <h4 class="col-12 mb-1 p-2 text-center text-white font-weight-bold article-title word-break">
-          aaaaaaaaaaaaaaaaaaaaaaaaaa
-        </h4>
-      </div>
-    </template> -->
   </div>
 </template>
 
@@ -256,26 +82,22 @@ export default {
   },
   data() {
     return {
-      tourings: [],
-      activities: [],
-      foods: [],
-      souvenirs: [],
-      accommodations: [],
-      transportations: [],
-      others: [],
-      totalTouringCost: 0,
-      totalActivityCost: 0,
-      totalFoodCost: 0,
-      totalSouvenirCost: 0,
-      totalAccommodationCost: 0,
-      totalTransportationCost: 0,
-      totalOtherCost: 0,
-      totalCost: 0
-    }
-  },
-  computed: {
-    totalCostComma() {
-      return this.totalCost.toLocaleString()
+      tourings: ['1', []],
+      activities: ['2', []],
+      foods: ['3', []],
+      souvenirs: ['4', []],
+      accommodations: ['5', []],
+      transportations: ['6', []],
+      others: ['7', []],
+      costs: [],
+      totalTouringCost: null,
+      totalActivityCost: null,
+      totalFoodCost: null,
+      totalSouvenirCost: null,
+      totalAccommodationCost: null,
+      totalTransportationCost: null,
+      totalOtherCost: null,
+      totalCost: null,
     }
   },
   created() {
@@ -283,48 +105,94 @@ export default {
   },
   methods :{
     classifyCost() {
-      return this.days.forEach(day => {
-        return day.info_blocks.forEach(info_block => {
+      this.days.forEach(day => {
+        day.info_blocks.forEach(info_block => {
           info_block.spendings.forEach(spending => {
             if (spending.genre == 'touring') {
-              this.tourings.push(spending)
+              this.tourings[1].push(spending)
               this.totalTouringCost += Number(spending.cost)
               this.totalCost += Number(spending.cost)
             } else if (spending.genre == 'activity') {
-              this.activities.push(spending)
+              this.activities[1].push(spending)
               this.totalActivityCost += Number(spending.cost)
               this.totalCost += Number(spending.cost)
             } else if (spending.genre == 'food') {
-              this.foods.push(spending)
+              this.foods[1].push(spending)
               this.totalFoodCost += Number(spending.cost)
               this.totalCost += Number(spending.cost)
             } else if (spending.genre == 'souvenir') {
-              this.souvenirs.push(spending)
+              this.souvenirs[1].push(spending)
               this.totalSouvenirCost += Number(spending.cost)
               this.totalCost += Number(spending.cost)
             } else if (spending.genre == 'accommodation') {
-              this.accommodations.push(spending)
+              this.accommodations[1].push(spending)
               this.totalAccommodationCost += Number(spending.cost)
               this.totalCost += Number(spending.cost)
             } else if (spending.genre == 'other') {
-              this.others.push(spending)
+              this.others[1].push(spending)
               this.totalOtherCost += Number(spending.cost)
               this.totalCost += Number(spending.cost)
             }
           })
           info_block.transportations.forEach(transportation => {
-            this.transportations.push(transportation)
+            this.transportations[1].push(transportation)
             this.totalTransportationCost += Number(transportation.cost)
             this.totalCost += Number(transportation.cost)
           })
         })
       })
+      this.costs.push(
+        this.tourings,
+        this.activities,
+        this.foods,
+        this.souvenirs,
+        this.accommodations,
+        this.transportations,
+        this.others
+      )
     },
     separateWithComma(num) {
       let cost = Number(num)
       return cost.toLocaleString()
     },
-    defaultTransportation(means) {
+    labelOrCost(genre) {
+      if (genre == 'touring')
+        return {
+          label: '観光費',
+          cost: this.separateWithComma(this.totalTouringCost)
+        }
+      if (genre == 'activity')
+        return {
+          label: 'アクティビティ費用',
+          cost: this.separateWithComma(this.totalActivityCost)
+        }
+      if (genre == 'food')
+        return {
+          label: '食費',
+          cost: this.separateWithComma(this.totalFoodCost)
+        }
+      if (genre == 'souvenir')
+        return {
+          label: 'お土産代',
+          cost: this.separateWithComma(this.totalSouvenirCost)
+        }
+      if (genre == 'accommodation')
+        return {
+          label: '宿泊費',
+          cost: this.separateWithComma(this.totalAccommodationCost)
+        }
+      if (genre == 'other')
+        return {
+          label: 'その他',
+          cost: this.separateWithComma(this.totalOtherCost)
+        }
+      if (genre == null)
+        return {
+          label: '交通費',
+          cost: this.separateWithComma(this.totalTransportationCost)
+        }
+    },
+    defaultTransportationDescription(means) {
       if (means == 'walking') return '徒歩'
       if (means == 'car') return '車'
       if (means == 'taxi') return 'タクシー'

--- a/app/javascript/pages/article/components/show/MainColumn.vue
+++ b/app/javascript/pages/article/components/show/MainColumn.vue
@@ -32,9 +32,9 @@
 </template>
 
 <script>
-import InfoBlock from './infoblock/InfoBlock'
-import InfoBlockSmall from './infoblock/InfoBlockSmall'
-import Transportation from './infoblock/Transportation'
+import InfoBlock from './maincolumn/InfoBlock'
+import InfoBlockSmall from './maincolumn/InfoBlockSmall'
+import Transportation from './maincolumn/Transportation'
 
 export default {
   name: 'MainColumn',

--- a/app/javascript/pages/article/components/show/MapColumn.vue
+++ b/app/javascript/pages/article/components/show/MapColumn.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="mb-4 text-center">
+    <template v-if="$mq == 'xs'">
+      <iframe
+        :src="map"
+        class="map-xs"
+      />
+    </template>
+    <template v-else>
+      <iframe
+        :src="map"
+        class="map"
+      />
+    </template>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'MapColumn',
+  components: {
+  },
+  props: {
+    map: {
+      type: String,
+      required: true
+    }
+  }
+}
+</script>
+
+<style scoped>
+.map {
+  width: 100%;
+  height: 480px;
+  border: solid #FF990D;
+  border-radius: 6px;
+}
+
+.map-xs {
+  width: 100%;
+  height: 400px;
+}
+</style>

--- a/app/javascript/pages/article/components/show/SideColumn.vue
+++ b/app/javascript/pages/article/components/show/SideColumn.vue
@@ -1,85 +1,41 @@
 <template>
   <div>
-    <template v-if="$mq == 'sm'">
-      <div class="row pl-3 pr-3 ml-sm-5 mr-sm-5 pl-sm-5 pr-sm-5">
-        <h4 class="col-12 mb-1 p-2 text-center text-white font-weight-bold article-title word-break">
-          {{ article.title }}
-        </h4>
-        <p class="col-12 text-muted text-center word-break article-info">
-          {{ article.region.country.name }}&nbsp;
-          {{ article.region.name }}&nbsp;
-          {{ article.start_date | moment('M/D(ddd)') }}〜{{ article.end_date | moment('M/D(ddd)') }}
+    <h4 class="col-12 mb-1 p-2 text-center text-white font-weight-bold article-title word-break">
+      {{ article.title }}
+    </h4>
+    <p class="col-12 text-muted text-center word-break article-info">
+      {{ article.region.country.name }}&nbsp;
+      {{ article.region.name }}&nbsp;
+      {{ article.start_date | moment('M/D(ddd)') }}〜{{ article.end_date | moment('M/D(ddd)') }}
+    </p>
+    <template v-if="article.description">
+      <div class="col-12 p-0 mb-3">
+        <p class="text-center text-white m-0 description-label">
+          概要
         </p>
-        <template v-if="article.description">
-          <div class="col-12 p-0 mb-3">
-            <p class="text-center text-white m-0 description-label">
-              概要
-            </p>
-            <p class="text-dark bg-white p-2 m-0 word-break description-main">
-              {{ article.description }}
-            </p>
-          </div>
-        </template>
-        <div class="col-12 d-flex justify-content-center align-items-center user-name">
-          <img
-            src="../../../../images/sample.png"
-            class="user-icon"
-          >
-          <h4 class="float-right mb-0 pl-2 word-break">
-            Ito Manabu
-          </h4>
-          <div class="text-center pl-4">
-            <font-awesome-icon
-              :icon="['far', 'thumbs-up']"
-              class="fa-lg"
-            />
-            <p class="m-0 word-break">
-              100
-            </p>
-          </div>
-        </div>
+        <p class="d-flex justify-content-center text-dark bg-white p-2 m-0 word-break description-main">
+          {{ article.description }}
+        </p>
       </div>
     </template>
-    <template v-else>
-      <div class="row sidebar_fixed pl-3 pr-3">
-        <h4 class="col-12 mb-1 p-2 text-center text-white font-weight-bold article-title word-break">
-          {{ article.title }}
-        </h4>
-        <p class="col-12 text-muted text-center word-break article-info">
-          {{ article.region.country.name }}&nbsp;
-          {{ article.region.name }}&nbsp;
-          {{ article.start_date | moment('M/D(ddd)') }}〜{{ article.end_date | moment('M/D(ddd)') }}
+    <div class="col-12 d-flex justify-content-center align-items-center user-name">
+      <img
+        src="../../../../images/sample.png"
+        class="user-icon"
+      >
+      <h4 class="float-right mb-0 pl-2 word-break">
+        Ito Manabu
+      </h4>
+      <div class="text-center pl-4">
+        <font-awesome-icon
+          :icon="['far', 'thumbs-up']"
+          class="fa-lg"
+        />
+        <p class="m-0 word-break">
+          100
         </p>
-        <template v-if="article.description">
-          <div class="col-12 p-0 mb-3">
-            <p class="text-center text-white m-0 description-label">
-              概要
-            </p>
-            <p class="text-dark bg-white p-2 m-0 word-break description-main">
-              {{ article.description }}
-            </p>
-          </div>
-        </template>
-        <div class="col-12 d-flex justify-content-center align-items-center user-name">
-          <img
-            src="../../../../images/sample.png"
-            class="user-icon"
-          >
-          <h4 class="float-right mb-0 pl-2 word-break">
-            Ito Manabu
-          </h4>
-          <div class="text-center pl-4">
-            <font-awesome-icon
-              :icon="['far', 'thumbs-up']"
-              class="fa-lg"
-            />
-            <p class="m-0 word-break">
-              100
-            </p>
-          </div>
-        </div>
       </div>
-    </template>
+    </div>
   </div>
 </template>
 

--- a/app/javascript/pages/article/components/show/SwitchButton.vue
+++ b/app/javascript/pages/article/components/show/SwitchButton.vue
@@ -1,0 +1,137 @@
+<template>
+  <div>
+    <div
+      v-for="day in article.days"
+      :key="day.id"
+      class="d-inline-block"
+    >
+      <template v-if="dayNumber == day.number">
+        <button class="btn mb-2 ml-1 mr-1 p-1 text-white font-weight-bold day-number-selected">
+          {{ day.number }}日目
+        </button>
+      </template>
+      <template v-else>
+        <button
+          class="btn mb-2 ml-1 mr-1 p-1 bg-white day-number"
+          @click="showMainColumn(day.number)"
+        >
+          {{ day.number }}日目
+        </button>
+      </template>
+    </div>
+    <template v-if="checkCostPresence">
+      <template v-if="costButtonSelected">
+        <button class="btn mb-2 ml-1 mr-1 p-1 text-white font-weight-bold total-cost-selected">
+          コスト
+        </button>
+      </template>
+      <template v-else>
+        <button
+          class="btn mb-2 ml-1 mr-1 p-1 bg-white total-cost"
+          @click="showCostColumn"
+        >
+          コスト
+        </button>
+      </template>
+    </template>
+    <template v-if="article.map">
+      <template v-if="mapButtonSelected">
+        <button class="btn mb-2 ml-1 mr-1 p-1 text-white font-weight-bold map-selected">
+          マップ
+        </button>
+      </template>
+      <template v-else>
+        <button
+          class="btn mb-2 ml-1 mr-1 p-1 bg-white map"
+          @click="showMapColumn"
+        >
+          マップ
+        </button>
+      </template>
+    </template>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'SwitchButton',
+  props: {
+    article: {
+      type: Object,
+      required: true
+    }
+  },
+  data() {
+    return {
+      dayNumber: 1,
+      costButtonSelected: false,
+      mapButtonSelected: false
+    }
+  },
+  computed: {
+    checkCostPresence() {
+      let cost = []
+      this.article.days.forEach(day => {
+        day.info_blocks.forEach(info_block => {
+          info_block.spendings.forEach(spending => {
+            cost.push(spending)
+          })
+          info_block.transportations.forEach(transportation => {
+            cost.push(transportation)
+          })
+        })
+      })
+      return cost.length? true : false
+    }
+  },
+  methods :{
+    showMainColumn(dayNumber) {
+      this.$emit('showMainColumn', dayNumber)
+      this.dayNumber = dayNumber
+      this.costButtonSelected = false
+      this.mapButtonSelected = false
+    },
+    showCostColumn() {
+      this.$emit('showCostColumn')
+      this.dayNumber = null
+      this.mapButtonSelected = false
+      this.costButtonSelected = true
+    },
+    showMapColumn() {
+      this.$emit('showMapColumn')
+      this.dayNumber = null
+      this.costButtonSelected = false
+      this.mapButtonSelected = true
+    },
+  }
+}
+</script>
+
+<style scoped>
+.day-number {
+  border: solid #00D320;
+}
+
+.day-number-selected {
+  background-color: #00D320;
+  border: solid #00D320;
+}
+
+.total-cost {
+  border: solid #1D51FF;
+}
+
+.total-cost-selected {
+  background-color: #1D51FF;
+  border: solid #1D51FF;
+}
+
+.map {
+  border: solid #FF990D;
+}
+
+.map-selected {
+  background-color: #FF990D;
+  border: solid #FF990D;
+}
+</style>

--- a/app/javascript/pages/article/components/show/maincolumn/InfoBlock.vue
+++ b/app/javascript/pages/article/components/show/maincolumn/InfoBlock.vue
@@ -2,12 +2,12 @@
   <div class="row mt-3 mb-3 ml-1 mr-1 bg-white info-block">
     <template v-if="block.arriving_time || block.leaving_time">
       <div class="col-1 pt-3 pb-3 pl-1 pr-1 info-block-left">
-        <InfoBlockLeft
+        <TimeInfo
           :block="block"
         />
       </div>
       <div class="col-6 p-3 info-block-center">
-        <InfoBlockCenter
+        <MainInfo
           :block="block"
         />
       </div>
@@ -20,7 +20,7 @@
     </template>
     <template v-else>
       <div class="col-7 p-3 info-block-left">
-        <InfoBlockCenter
+        <MainInfo
           :block="block"
         />
       </div>
@@ -35,24 +35,19 @@
 </template>
 
 <script>
-import InfoBlockCenter from './parts/InfoBlockCenter'
-import InfoBlockLeft from './parts/InfoBlockLeft'
+import TimeInfo from './infoblock/TimeInfo'
+import MainInfo from './infoblock/MainInfo'
 
 export default {
   name: 'InfoBlock',
   components: {
-    InfoBlockLeft,
-    InfoBlockCenter
+    TimeInfo,
+    MainInfo
   },
   props: {
     block: {
       type: Object,
       required: true
-    }
-  },
-  data() {
-    return {
-      date: this.$moment().format()
     }
   },
 }

--- a/app/javascript/pages/article/components/show/maincolumn/InfoBlockSmall.vue
+++ b/app/javascript/pages/article/components/show/maincolumn/InfoBlockSmall.vue
@@ -2,12 +2,12 @@
   <div class="row mb-3 bg-white">
     <template v-if="block.arriving_time || block.leaving_time">
       <div class="col-2 pt-3 pb-3 pl-2 pr-2 info-block-left">
-        <InfoBlockLeft
+        <TimeInfo
           :block="block"
         />
       </div>
       <div class="col-10 p-3 info-block-right">
-        <InfoBlockCenter
+        <MainInfo
           :block="block"
         />
       </div>
@@ -20,7 +20,7 @@
     </template>
     <template v-else>
       <div class="col-12 p-3 info-block-above-without-time">
-        <InfoBlockCenter
+        <MainInfo
           :block="block"
         />
       </div>
@@ -35,24 +35,19 @@
 </template>
 
 <script>
-import InfoBlockLeft from './parts/InfoBlockLeft'
-import InfoBlockCenter from './parts/InfoBlockCenter'
+import TimeInfo from './infoblock/TimeInfo'
+import MainInfo from './infoblock/MainInfo'
 
 export default {
   name: 'InfoBlockSmall',
   components: {
-    InfoBlockLeft,
-    InfoBlockCenter
+    TimeInfo,
+    MainInfo
   },
   props: {
     block: {
       type: Object,
       required: true
-    }
-  },
-  data() {
-    return {
-      date: this.$moment().format()
     }
   },
 }
@@ -61,13 +56,11 @@ export default {
 <style scoped>
 .info-block-left {
   border: solid #FF00EB;
-  /* border-color: #FF00EB #CBCBCB #CBCBCB #FF00EB; */
   border-width: 0.1px 0.1px 0.1px 0px;
 }
 
 .info-block-right {
   border: solid #FF00EB;
-  /* border-color: #FF00EB #FF00EB #CBCBCB #FF00EB; */
   border-width: 0.1px 0px 0.1px 0px;
 }
 
@@ -78,7 +71,6 @@ export default {
 
 .info-block-above-without-time {
   border: solid #FF00EB;
-  /* border-color: #FF00EB #FF00EB #CBCBCB #FF00EB; */
   border-width: 0.1px 0px 0.1px 0px;
 }
 

--- a/app/javascript/pages/article/components/show/maincolumn/Transportation.vue
+++ b/app/javascript/pages/article/components/show/maincolumn/Transportation.vue
@@ -43,7 +43,7 @@
 
 <script>
 export default {
-  name: 'MainColumn',
+  name: 'Transportation',
   props: {
     block: {
       type: Object,

--- a/app/javascript/pages/article/components/show/maincolumn/infoblock/MainInfo.vue
+++ b/app/javascript/pages/article/components/show/maincolumn/infoblock/MainInfo.vue
@@ -81,7 +81,7 @@
 
 <script>
 export default {
-  name: 'InfoBlockCenter',
+  name: 'MainInfo',
   props: {
     block: {
       type: Object,

--- a/app/javascript/pages/article/components/show/maincolumn/infoblock/TimeInfo.vue
+++ b/app/javascript/pages/article/components/show/maincolumn/infoblock/TimeInfo.vue
@@ -49,16 +49,11 @@
 
 <script>
 export default {
-  name: 'InfoBlockLeft',
+  name: 'TimeInfo',
   props: {
     block: {
       type: Object,
       required: true
-    }
-  },
-  data() {
-    return {
-      date: this.$moment().format()
     }
   },
 }

--- a/app/javascript/pages/article/index.vue
+++ b/app/javascript/pages/article/index.vue
@@ -1,15 +1,40 @@
 <template>
-  <ArticleList :articles="articles" />
+  <div class="container-fluid mt-2">
+    <template v-if="$mq == 'lg'">
+      <div class="row">
+        <ArticleList
+          :articles="articles"
+          class="col-8"
+        />
+        <SearchColumn
+          class="col-4"
+        />
+      </div>
+    </template>
+    <template v-else>
+      <div class="row">
+        <SearchColumn
+          class="col-12"
+        />
+        <ArticleList
+          :articles="articles"
+          class="col-12"
+        />
+      </div>
+    </template>
+  </div>
 </template>
 
 <script>
 import ArticleList from './components/index/ArticleList'
+import SearchColumn from './components/index/SearchColumn'
 import { mapGetters, mapActions } from 'vuex'
 
 export default {
   name: 'ArticleIndex',
   components: {
     ArticleList,
+    SearchColumn
   },
   computed: {
     ...mapGetters('articles', [
@@ -28,4 +53,9 @@ export default {
 </script>
 
 <style scoped>
+.container-fluid {
+  max-width: 1000px;
+  margin-right: auto;
+  margin-left: auto;
+}
 </style>

--- a/app/javascript/pages/article/show.vue
+++ b/app/javascript/pages/article/show.vue
@@ -3,50 +3,13 @@
     <template v-if="$mq == 'lg'">
       <div class="row">
         <div class="col-8 text-center">
-          <div
-            v-for="day in articleDetail.days"
-            :key="day.id"
-            class="d-inline-block"
-          >
-            <template v-if="dayNumber == day.number">
-              <button
-                class="btn mb-2 ml-1 mr-1 p-1 text-white font-weight-bold day-number-selected"
-                @click="showArticleDetail(day.number)"
-              >
-                {{ day.number }}日目
-              </button>
-            </template>
-            <template v-else>
-              <button
-                class="btn mb-2 ml-1 mr-1 p-1 bg-white day-number"
-                @click="showArticleDetail(day.number)"
-              >
-                {{ day.number }}日目
-              </button>
-            </template>
-          </div>
-          <template v-if="checkCostPresence">
-            <template v-if="isVisibleCostColumn">
-              <button
-                class="btn mb-2 ml-1 mr-1 p-1 text-white font-weight-bold total-cost-selected"
-                @click="showCostColumn"
-              >
-                総コスト
-              </button>
-            </template>
-            <template v-else>
-              <button
-                class="btn mb-2 ml-1 mr-1 p-1 bg-white total-cost"
-                @click="showCostColumn"
-              >
-                総コスト
-              </button>
-            </template>
-          </template>
+          <SwitchButton
+            :article="articleDetail"
+            @showMainColumn="showMainColumn"
+            @showCostColumn="showCostColumn"
+            @showMapColumn="showMapColumn"
+          />
         </div>
-      </div>
-
-      <div class="row">
         <div class="col-8">
           <div
             v-for="day in articleDetail.days"
@@ -63,67 +26,50 @@
           :days="articleDetail.days"
           class="col-8"
         />
-        <SideColumn
-          :article="articleDetail"
-          class="col-4"
+        <MapColumn
+          v-if="isVisibleMapColumn"
+          :map="articleDetail.map"
+          class="col-8"
         />
+        <div class="col-4">
+          <div class="row pl-3 pr-3">
+            <SideColumn
+              :article="articleDetail"
+            />
+          </div>
+        </div>
       </div>
     </template>
-
     <template v-else>
       <div class="row">
-        <SideColumn
-          :article="articleDetail"
-          class="col-12"
-        />
-
+        <div class="col-12">
+          <template v-if="$mq == 'sm'">
+            <div class="row pl-3 pr-3 ml-sm-5 mr-sm-5 pl-sm-5 pr-sm-5">
+              <SideColumn
+                :article="articleDetail"
+              />
+            </div>
+          </template>
+          <template v-else>
+            <div class="row pl-3 pr-3">
+              <SideColumn
+                :article="articleDetail"
+              />
+            </div>
+          </template>
+        </div>
         <div class="col-12 mt-4">
           <div class="row">
             <div class="col-12 text-center">
-              <div
-                v-for="day in articleDetail.days"
-                :key="day.id"
-                class="d-inline-block"
-              >
-                <template v-if="dayNumber == day.number">
-                  <button
-                    class="btn mb-2 mr-1 ml-1 p-1 text-white font-weight-bold day-number-selected"
-                    @click="showArticleDetail(day.number)"
-                  >
-                    {{ day.number }}日目
-                  </button>
-                </template>
-                <template v-else>
-                  <button
-                    class="btn mb-2 mr-1 ml-1 p-1 bg-white day-number"
-                    @click="showArticleDetail(day.number)"
-                  >
-                    {{ day.number }}日目
-                  </button>
-                </template>
-              </div>
-              <template v-if="checkCostPresence">
-                <template v-if="isVisibleCostColumn">
-                  <button
-                    class="btn mb-2 p-1 ml-1 mr-1 text-white font-weight-bold total-cost-selected"
-                    @click="showCostColumn"
-                  >
-                    総コスト
-                  </button>
-                </template>
-                <template v-else>
-                  <button
-                    class="btn mb-2 ml-1 mr-1 p-1 bg-white total-cost"
-                    @click="showCostColumn"
-                  >
-                    総コスト
-                  </button>
-                </template>
-              </template>
+              <SwitchButton
+                :article="articleDetail"
+                @showMainColumn="showMainColumn"
+                @showCostColumn="showCostColumn"
+                @showMapColumn="showMapColumn"
+              />
             </div>
           </div>
         </div>
-
         <div class="col-12">
           <div
             v-for="day in articleDetail.days"
@@ -135,12 +81,25 @@
             />
           </div>
         </div>
-
         <CostColumn
           v-if="isVisibleCostColumn"
           :days="articleDetail.days"
           class="col-12"
         />
+        <template v-if="$mq == 'xs'">
+          <MapColumn
+            v-if="isVisibleMapColumn"
+            :map="articleDetail.map"
+            class="col-12 p-0"
+          />
+        </template>
+        <template v-else>
+          <MapColumn
+            v-if="isVisibleMapColumn"
+            :map="articleDetail.map"
+            class="col-12"
+          />
+        </template>
       </div>
     </template>
   </div>
@@ -150,6 +109,8 @@
 import MainColumn from './components/show/MainColumn'
 import SideColumn from './components/show/SideColumn'
 import CostColumn from './components/show/CostColumn'
+import MapColumn from './components/show/MapColumn'
+import SwitchButton from './components/show/SwitchButton'
 import { mapGetters, mapActions } from 'vuex'
 
 export default {
@@ -157,32 +118,21 @@ export default {
   components: {
     MainColumn,
     SideColumn,
-    CostColumn
+    CostColumn,
+    MapColumn,
+    SwitchButton
   },
   data() {
     return {
       dayNumber: 1,
-      isVisibleCostColumn: false
+      isVisibleCostColumn: false,
+      isVisibleMapColumn: false
     }
   },
   computed: {
     ...mapGetters('articles', [
       'articleDetail'
     ]),
-    checkCostPresence() {
-      let cost = []
-      this.articleDetail.days.forEach(day => {
-        day.info_blocks.forEach(info_block => {
-          info_block.spendings.forEach(spending => {
-            cost.push(spending)
-          })
-          info_block.transportations.forEach(transportation => {
-            cost.push(transportation)
-          })
-        })
-      })
-      return cost.length? true : false
-    }
   },
   created() {
     this.getArticleDetail(this.$route.query.id)
@@ -191,13 +141,20 @@ export default {
     ...mapActions('articles', [
       'getArticleDetail'
     ]),
-    showArticleDetail(dayNumber) {
+    showMainColumn(dayNumber) {
       this.dayNumber = dayNumber
       this.isVisibleCostColumn = false
+      this.isVisibleMapColumn = false
     },
     showCostColumn() {
       this.dayNumber = null
+      this.isVisibleMapColumn = false
       this.isVisibleCostColumn = true
+    },
+    showMapColumn() {
+      this.dayNumber = null
+      this.isVisibleCostColumn = false
+      this.isVisibleMapColumn = true
     },
   }
 }
@@ -205,36 +162,8 @@ export default {
 
 <style scoped>
 .container-fluid {
-  max-width: 1100px;
+  max-width: 1000px;
   margin-right: auto;
   margin-left: auto;
-}
-
-.main-column {
-  border: solid thin #00FF27;
-  border-radius: 6px;
-}
-
-.day-number {
-  border: solid #00D320;
-}
-
-.day-number-selected {
-  background-color: #00D320;
-  border: solid #00D320;
-}
-
-.day-number-selected-xs {
-  background-color: #00D320;
-  border: solid #00D320;
-}
-
-.total-cost {
-  border: solid #1D51FF;
-}
-
-.total-cost-selected {
-  background-color: #1D51FF;
-  border: solid #1D51FF;
 }
 </style>

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,7 +1,15 @@
 class Article < ApplicationRecord
+  before_save :extract_url_from_map
+
   has_many :days, dependent: :destroy
   belongs_to :region
 
   validates :title, presence: true
   validates :status, presence: true
+
+  private
+
+  def extract_url_from_map
+    self.map = URI.extract(map, ['https']).first
+  end
 end

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -1,5 +1,5 @@
 class ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :description, :start_date, :end_date, :created_at
+  attributes :id, :title, :description, :map, :start_date, :end_date, :created_at
   has_one :region
   has_many :days
 

--- a/db/migrate/20210219131938_create_articles.rb
+++ b/db/migrate/20210219131938_create_articles.rb
@@ -4,6 +4,7 @@ class CreateArticles < ActiveRecord::Migration[6.1]
       t.references :region, null: false, foreign_key: true
       t.string :title, null: false
       t.text :description
+      t.string :map
       t.integer :status, default: 0, null: false
       t.date :start_date
       t.date :end_date

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,6 +16,7 @@ ActiveRecord::Schema.define(version: 2021_03_01_123035) do
     t.bigint "region_id", null: false
     t.string "title", null: false
     t.text "description"
+    t.string "map"
     t.integer "status", default: 0, null: false
     t.date "start_date"
     t.date "end_date"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,7 +13,7 @@
 #   Country.first.regions.create!(name: prefecture)
 # end
 
-5.times do
+3.times do
   country = Country.create!(
     name: Faker::Nation.nationality,
     currency: Faker::Nation.language
@@ -27,6 +27,7 @@
     article = region.articles.create!(
       title: Faker::Movies::StarWars.character,
       description: Faker::Movies::BackToTheFuture.quote,
+      map: '<iframe src="https://www.google.com/maps/d/u/0/embed?mid=17HzQVLk9-3JyLYxvCBQmvWjtlaomn4xd" width="640" height="480"></iframe>',
       start_date: Date.today,
       end_date: Date.tomorrow
     )
@@ -38,12 +39,12 @@
       m = rand(2..5)
       m.times do
         info_block = day.info_blocks.create(
-          arriving_time: Time.now,
-          leaving_time: Time.now + m.minutes,
           event: Faker::JapaneseMedia::DragonBall.character,
           place: Faker::JapaneseMedia::OnePiece.character,
           comment: Faker::Movies::BackToTheFuture.quote,
-          position: 1
+          position: 1,
+          arriving_time: Time.now,
+          leaving_time: Time.now + m.minutes,
         )
 
         x = rand(0..3)
@@ -58,7 +59,7 @@
         y = rand(1..2)
         y.times do
           info_block.transportations.create(
-            means: rand(0..8),
+            means: rand(0..9),
             description: Faker::JapaneseMedia::Doraemon.character,
             cost: rand(100..2000)
           )

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :article do
     sequence(:title) { |n| "TestTitle#{n}" }
     sequence(:description) { |n| "TestDescription#{n}" }
+    map { '<iframe src="https://www.google.com/maps/d/u/0/embed?mid=17HzQVLk9-3JyLYxvCBQmvWjtlaomn4xd" width="640" height="480"></iframe>' }
     status { 0 }
     start_date { Date.today }
     end_date { Date.tomorrow }

--- a/spec/system/articles_spec.rb
+++ b/spec/system/articles_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Articles", type: :system do
       it '記事詳細ブロックが表示される' do
         article_normal
         visit root_path
-        find('.article-main').click
+        click_on article_normal.title
         expect(page).to have_content('時間')
         expect(page).to have_content('イベント')
         expect(page).to have_content('場所')
@@ -43,7 +43,7 @@ RSpec.describe "Articles", type: :system do
       it 'データがない場合はラベルが表示されない' do
         article_only_with_event
         visit root_path
-        find('.article-main').click
+        click_on article_only_with_event.title
         expect(page).to_not have_content('時間')
         expect(page).to_not have_content('場所')
         expect(page).to_not have_content('コスト')
@@ -55,7 +55,7 @@ RSpec.describe "Articles", type: :system do
       it '記事概要が表示される' do
         article_normal
         visit root_path
-        find('.article-main').click
+        click_on article_normal.title
         expect(page).to have_content(article_normal.title)
         expect(page).to have_content(article_normal.region.country.name)
         expect(page).to have_content(article_normal.region.name)
@@ -63,27 +63,50 @@ RSpec.describe "Articles", type: :system do
       end
     end
 
-    describe '総コスト' do
-      it '総コストボタンが表示される' do
+    describe '日付ボタン' do
+      it '日付ボタンが表示される' do
         article_normal
         visit root_path
-        find('.article-main').click
-        expect(page).to have_content('総コスト')
+        click_on article_normal.title
+        expect(page).to have_content('1日目')
+        expect(page).to have_content('2日目')
+        expect(page).to have_content('3日目')
       end
 
-      it 'コストが保存されていない場合は総コストボタンが表示されない' do
-        article_only_with_event
-        visit root_path
-        find('.article-main').click
-        expect(page).to_not have_content('総コスト')
-      end
-
-      context '総コストボタンを押す' do
-        it '総コストが表示される' do
+      context '日付ボタンを押す' do
+        it '記事情報ブロックカラムが切り替わる' do
           article_normal
           visit root_path
-          find('.article-main').click
-          click_on '総コスト'
+          click_on article_normal.title
+          click_on '2日目'
+          expect(page).to have_content(article_normal.days.second.info_blocks.first.event)
+          click_on '3日目'
+          expect(page).to have_content(article_normal.days.third.info_blocks.first.event)
+        end
+      end
+    end
+
+    describe 'コスト' do
+      it 'コストボタンが表示されている' do
+        article_normal
+        visit root_path
+        click_on article_normal.title
+        expect(page).to have_content('コスト')
+      end
+
+      it 'コストが保存されていない場合はコストボタンが表示されない' do
+        article_only_with_event
+        visit root_path
+        click_on article_only_with_event.title
+        expect(page).to_not have_content('コスト')
+      end
+
+      context 'コストボタンを押す' do
+        it 'コスト一覧が表示される' do
+          article_normal
+          visit root_path
+          click_on article_normal.title
+          click_on 'コスト'
           expect(page).to have_content('観光費')
           expect(page).to have_content('アクティビティ費')
           expect(page).to have_content('食費')
@@ -95,25 +118,24 @@ RSpec.describe "Articles", type: :system do
         end
       end
 
-      it 'データのない項目のラベルは総コストに表示されない' do
+      it 'データのない項目のラベルはコスト一覧に表示されない' do
         article_without_transportation_cost
         visit root_path
-        find('.article-main').click
-        click_on '総コスト'
+        click_on article_without_transportation_cost.title
+        click_on 'コスト'
         expect(page).to_not have_content('観光費')
         expect(page).to_not have_content('アクティビティ費')
         expect(page).to_not have_content('食費')
         expect(page).to_not have_content('お土産代')
         expect(page).to_not have_content('宿泊費')
         expect(page).to_not have_content('その他')
-        page.save_screenshot 'screenshot.png'
       end
 
-      it '交通手段のコストが保存されていない場合は総コストに表示されない' do
+      it '交通手段のコストが保存されていない場合はコスト一覧に表示されない' do
         article_without_transportation_cost
         visit root_path
-        find('.article-main').click
-        click_on '総コスト'
+        click_on article_without_transportation_cost.title
+        click_on 'コスト'
         expect(page).to_not have_content(
           article_without_transportation_cost.days.first.info_blocks.first.transportations.first.description
         )
@@ -122,8 +144,8 @@ RSpec.describe "Articles", type: :system do
       it '交通手段の説明が保存されていない場合は交通手段の名前が説明として総コストに表示される' do
         article_without_transportation_description
         visit root_path
-        find('.article-main').click
-        click_on '総コスト'
+        click_on article_without_transportation_description.title
+        click_on 'コスト'
         expect(page).to have_content('車')
         expect(page).to have_content('タクシー')
         expect(page).to have_content('バス')
@@ -136,25 +158,22 @@ RSpec.describe "Articles", type: :system do
       end
     end
 
-    describe '日付ボタン' do
-      it '日付ボタンが表示される' do
+    describe 'マップ' do
+      it 'マップボタンが表示されている' do
         article_normal
         visit root_path
-        find('.article-main').click
-        expect(page).to have_content('1日目')
-        expect(page).to have_content('2日目')
-        expect(page).to have_content('3日目')
+        click_on article_normal.title
+        expect(page).to have_content('マップ')
       end
 
-      context '日付ボタンを押す' do
-        it '記事情報ブロックカラムが切り替わる' do
+      context 'マップボタンを押す' do
+        it 'マップが表示される' do
           article_normal
           visit root_path
-          find('.article-main').click
-          click_on '2日目'
-          expect(page).to have_content(article_normal.days.second.info_blocks.first.event)
-          click_on '3日目'
-          expect(page).to have_content(article_normal.days.third.info_blocks.first.event)
+          click_on article_normal.title
+          click_on 'マップ'
+          expect(page).to have_css('.map')
+          page.save_screenshot 'screenshot.png'
         end
       end
     end


### PR DESCRIPTION
## 概要

- `Articlesテーブル`にmapカラムを追加。
- mapカラムに`google my maps`の埋め込みHTMLを保存する際に、埋め込みHTMLからURLだけ抽出して保存するように設定。
- 記事詳細ページにマップボタンを配置し、それをクリックすることで保存した`google my maps`が表示される。

## 確認方法

1. 記事詳細ページにアクセス。
2. マップボタンをクリック。
3. `google my maps`が表示されること確認。

## チェックリスト

- システムスペックを追加
- rubocopをパス
- eslintをパス