### PR TITLE
画像削除機能追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,9 +40,6 @@ gem 'sorcery'
 gem 'aws-sdk-s3', require: false
 gem 'mini_magick'
 
-# Active Storage Validation
-gem 'activestorage-validator'
-
 # pagination
 gem 'kaminari'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,8 +63,6 @@ GEM
       activesupport (= 6.1.3.1)
       marcel (~> 1.0.0)
       mini_mime (~> 1.0.2)
-    activestorage-validator (0.1.3)
-      rails (>= 5.2.0)
     activesupport (6.1.3.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
@@ -349,7 +347,6 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers
-  activestorage-validator
   aws-sdk-s3
   better_errors
   binding_of_caller

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -1,6 +1,6 @@
 class Api::ArticlesController < ApplicationController
-  before_action :authenticate!, only: %i[create update destroy]
-  before_action :set_article, only: %i[show update destroy]
+  before_action :authenticate!, only: %i[create update destroy delete_eyecatch]
+  before_action :set_article, only: %i[update destroy delete_eyecatch]
   skip_before_action :verify_authenticity_token
 
   include Pagination
@@ -57,6 +57,7 @@ class Api::ArticlesController < ApplicationController
   end
 
   def show
+    @article = Article.include_relations.find(params[:id])
     render json: @article
   end
 
@@ -83,10 +84,14 @@ class Api::ArticlesController < ApplicationController
     render json: @article
   end
 
+  def delete_eyecatch
+    @article.eyecatch.purge if @article.eyecatch.attached?
+  end
+
   private
 
   def set_article
-    @article = Article.include_relations.find(params[:id])
+    @article = Article.find(params[:id])
   end
 
   def article_params

--- a/app/controllers/api/blocks_controller.rb
+++ b/app/controllers/api/blocks_controller.rb
@@ -1,6 +1,6 @@
 class Api::BlocksController < ApplicationController
   before_action :authenticate!
-  before_action :set_block, only: %i[update destroy]
+  before_action :set_block, only: %i[update destroy delete_image delete_image]
   skip_before_action :verify_authenticity_token
 
   def create
@@ -24,6 +24,10 @@ class Api::BlocksController < ApplicationController
   def destroy
     @block.destroy!
     render json: @block
+  end
+
+  def delete_image
+    @block.image.purge if @block.image.attached?
   end
 
   private

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,5 +1,5 @@
 class Api::UsersController < ApplicationController
-  before_action :authenticate!, only: %i[update update_current_user destroy_current_user]
+  before_action :authenticate!, only: %i[update update_current_user destroy_current_user reset_avatar]
   skip_before_action :verify_authenticity_token
 
   def show
@@ -37,6 +37,11 @@ class Api::UsersController < ApplicationController
   def me
     user = current_user.as_json(only: %i[id name email description])
     render json: user.merge(avatar_url: current_user.avatar_url)
+  end
+
+  def reset_avatar
+    user = User.find(params[:id])
+    user.avatar.attach(io: File.open(Rails.root.join('app', 'assets', 'images', 'default.jpg')), filename: 'default-image.jpg', content_type: 'image/png')
   end
 
   private

--- a/app/javascript/components/FooterTermAndPolicy.vue
+++ b/app/javascript/components/FooterTermAndPolicy.vue
@@ -37,8 +37,8 @@
     <template v-else>
       <router-link :to="{ name: 'TermOfUse' }">
         <a
-          href="#"
           id="term-of-use"
+          href="#"
           class="mr-2 p-0 d-inline-block text-muted"
         >
           利用規約
@@ -47,8 +47,8 @@
 
       <router-link :to="{ name: 'PrivacyPolicy' }">
         <a
-          href="#"
           id="privacy-policy"
+          href="#"
           class="mr-2 ml-2 p-0 d-inline-block text-muted"
         >
           プライバシーポリシー
@@ -56,9 +56,9 @@
       </router-link>
 
       <a
+        id="contact"
         href="https://docs.google.com/forms/d/e/1FAIpQLSff4mAzKQAal88lGp0Pl9sJTcfgsterdaB7d9CUupKOxyEhpA/viewform?usp=sf_link"
         target="_blank"
-        id="contact"
         class="mr-2 ml-2 p-0 d-inline-block text-muted"
       >
         お問い合わせ

--- a/app/javascript/components/TermAndPolicyLink.vue
+++ b/app/javascript/components/TermAndPolicyLink.vue
@@ -2,8 +2,8 @@
   <div class="col-12 mt-1 p-0 text-center font-xs-small">
     <router-link :to="{ name: 'TermOfUse' }">
       <a
-        href="#"
         id="term-of-use"
+        href="#"
         class="mr-1 ml-1 m-0 p-0 text-muted d-inline-block"
       >
         利用規約
@@ -11,17 +11,17 @@
     </router-link>
     <router-link :to="{ name: 'PrivacyPolicy' }">
       <a
-        href="#"
         id="privacy-policy"
+        href="#"
         class="mr-1 ml-1 m-0 p-0 text-muted d-inline-block"
       >
         プライバシーポリシー
       </a>
     </router-link>
     <a
+      id="contact"
       href="https://docs.google.com/forms/d/e/1FAIpQLSff4mAzKQAal88lGp0Pl9sJTcfgsterdaB7d9CUupKOxyEhpA/viewform?usp=sf_link"
       target="_blank"
-      id="contact"
       class="mr-1 ml-1 p-0 text-muted d-inline-block"
     >
       お問い合わせ

--- a/app/javascript/components/TheFooter.vue
+++ b/app/javascript/components/TheFooter.vue
@@ -73,7 +73,7 @@
         <!-- PEN ICON -->
         <ul class="navbar-nav">
           <li class="nav-item active m-0">
-            <template v-if="currentPage == 'pen'">
+            <template v-if="currentPage == 'create'">
               <router-link
                 :to="{ name: 'ArticleCreateOverview' }"
                 class="icon-selected"
@@ -90,7 +90,7 @@
                 :to="{ name: 'ArticleCreateOverview' }"
                 class="icon-color"
               >
-                <div @click="setCurrentPage('pen')">
+                <div @click="setCurrentPage('create')">
                   <font-awesome-icon
                     :icon="['fas', 'pen']"
                     class="fa-lg"

--- a/app/javascript/components/TheHeader.vue
+++ b/app/javascript/components/TheHeader.vue
@@ -22,28 +22,28 @@
                 <div slot="dropdown">
                   <div
                     v-if="this.$route.path != '/account_settings'"
-                    @click="accouSettings"
                     class="dropdown-item"
+                    @click="accouSettings"
                   >
                     アカウント設定
                   </div>
                   <div
                     v-if="this.$route.path != '/term_of_use'"
-                    @click="toTermOfUse"
                     class="dropdown-item"
+                    @click="toTermOfUse"
                   >
                     利用規約
                   </div>
                   <div
                     v-if="this.$route.path != '/privacy_policy'"
-                    @click="toPrivacyPolicy"
                     class="dropdown-item"
+                    @click="toPrivacyPolicy"
                   >
                     プライバシーポリシー
                   </div>
                   <div
-                    @click="logout"
                     class="dropdown-item"
+                    @click="logout"
                   >
                     ログアウト
                   </div>

--- a/app/javascript/pages/article/components/createdetail/BlockForm.vue
+++ b/app/javascript/pages/article/components/createdetail/BlockForm.vue
@@ -363,40 +363,55 @@
             v-slot="{ errors }"
             ref="provider"
             name="写真"
-            rules="image"
+            rules="image|size:5242.88"
           >
-            <p class="mt-4 text-center text-white content-lavel m-0">
-              写真
-            </p>
-            <template v-if="previewImage">
-              <img
-                :src="previewImage"
-                class="mt-2 image"
-              >
-            </template>
-            <div class="text-center">
-              <label class="mt-2 mb-4">
-                <template v-if="isMobile">
-                  <p class="mb-0 pl-3 pr-3 text-dark file-button-mobile">
-                    画像を選択
-                  </p>
-                </template>
-                <template v-else>
-                  <p class="mb-0 pl-3 pr-3 text-dark file-button">
-                    画像を選択
-                  </p>
-                </template>
-                <input
-                  id="image"
-                  type="file"
-                  accept="image/png,image/jpeg"
-                  name="写真"
-                  class="d-none"
-                  @change="handleChange"
+            <div class="mb-4">
+              <p class="mt-4 text-center text-white content-lavel m-0">
+                写真
+              </p>
+              <template v-if="previewImage">
+                <img
+                  :src="previewImage"
+                  class="mt-2 mb-1 image"
                 >
-              </label>
+                <div class="text-center">
+                  <div
+                    @click="deleteImage"
+                    id="delete-btn"
+                    class="d-inline-block icon"
+                  >
+                    <font-awesome-icon
+                      :icon="['far', 'times-circle']"
+                      class="fa-lg"
+                    />
+                  </div>
+                </div>
+              </template>
+              <div class="text-center">
+                <label class="mt-2">
+                  <template v-if="isMobile">
+                    <p class="mb-0 pl-3 pr-3 text-dark file-button-mobile">
+                      画像を選択
+                    </p>
+                  </template>
+                  <template v-else>
+                    <p class="mb-0 pl-3 pr-3 text-dark file-button">
+                      画像を選択
+                    </p>
+                  </template>
+                  <input
+                    v-if="isVisibleFileInput"
+                    id="image"
+                    type="file"
+                    accept="image/png,image/jpeg"
+                    name="写真"
+                    class="d-none"
+                    @change="handleChange"
+                  >
+                </label>
+              </div>
+              <span class="text-danger">{{ errors[0] }}</span>
             </div>
-            <span class="text-danger">{{ errors[0] }}</span>
           </ValidationProvider>
 
           <template v-if="$mq == 'lg'">
@@ -490,6 +505,7 @@ export default {
       isVisibleForm: true,
       height: '',
       previewImage: '',
+      isVisibleFileInput: true,
       isMobile: isMobile
     }
   },
@@ -567,6 +583,12 @@ export default {
     },
     closeForm() {
       this.isVisibleForm = false
+    },
+    deleteImage() {
+      this.previewImage = ''
+      this.blockAndCost.block.uploadImage = ''
+      this.isVisibleFileInput = false
+      this.$nextTick(() => (this.isVisibleFileInput = true))
     },
     resize(){
       this.height = 'auto'
@@ -737,5 +759,15 @@ export default {
 
 .add-block-msg {
   color: #FF990D;
+}
+
+.icon {
+  color: gray;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.icon:hover {
+  color: #383838;
 }
 </style>

--- a/app/javascript/pages/article/components/createdetail/blocklist/BlockEditForm.vue
+++ b/app/javascript/pages/article/components/createdetail/blocklist/BlockEditForm.vue
@@ -323,7 +323,7 @@
                 v-slot="{ errors }"
                 ref="provider"
                 name="写真"
-                rules="image"
+                rules="image|size:5242.88"
               >
                 <p class="mt-4 text-center text-white content-lavel m-0">
                   写真
@@ -331,40 +331,72 @@
                 <template v-if="previewImage">
                   <img
                     :src="previewImage"
+                    id="preview-image"
                     class="mt-2 image"
                   >
                 </template>
                 <template v-else>
-                  <template v-if="block.image_url">
+                  <template v-if="image">
                     <img
-                      :src="block.image_url"
+                      :src="image"
                       class="mt-2 image"
                     >
                   </template>
                 </template>
+                <template v-if="previewImage || image">
+                  <div class="mt-1 text-center">
+                    <div
+                      id="delete-btn"
+                      class="d-inline-block icon"
+                      @click="deleteImage"
+                    >
+                      <font-awesome-icon
+                        :icon="['far', 'times-circle']"
+                        class="fa-lg"
+                      />
+                    </div>
+                  </div>
+                </template>
+
                 <div class="text-center">
                   <label class="mt-2">
-                    <template v-if="isMobile">
-                      <p class="mb-0 pl-3 pr-3 text-dark file-button-mobile">
-                        画像を選択
-                      </p>
+                    <template v-if="$mq == 'xs'">
+                      <template v-if="isMobile">
+                        <p class="mb-0 pl-3 pr-3 text-dark file-button-mobile">
+                          画像を選択
+                        </p>
+                      </template>
+                      <template v-else>
+                        <p class="mb-0 pl-3 pr-3 text-dark file-button">
+                          画像を選択
+                        </p>
+                      </template>
+                      <input
+                        v-if="isVisibleFileInput"
+                        id="image"
+                        type="file"
+                        accept="image/png,image/jpeg"
+                        name="写真"
+                        class="d-none"
+                        @change="handleChange"
+                      >
                     </template>
                     <template v-else>
-                      <p class="mb-0 pl-3 pr-3 text-dark file-button">
-                        画像を選択
-                      </p>
+                      <input
+                        v-if="isVisibleFileInput"
+                        id="image"
+                        type="file"
+                        accept="image/png,image/jpeg"
+                        name="写真"
+                        class="form-control-file mx-auto file-input"
+                        @change="handleChange"
+                      >
                     </template>
-                    <input
-                      id="image"
-                      type="file"
-                      accept="image/png,image/jpeg"
-                      name="写真"
-                      class="d-none"
-                      @change="handleChange"
-                    >
                   </label>
                 </div>
-                <span class="text-danger">{{ errors[0] }}</span>
+                <p class="text-center text-danger">
+                  {{ errors[0] }}
+                </p>
               </ValidationProvider>
             </div>
           </div>
@@ -438,6 +470,8 @@ export default {
       transportationsIndex: 0,
       height: '',
       previewImage: '',
+      image: '',
+      isVisibleFileInput: true,
       isMobile: isMobile
     }
   },
@@ -469,6 +503,7 @@ export default {
       this.blockEdit.block.transportations[i].index = i
     }
     this.transportationsIndex = this.blockEdit.block.transportations.length
+    this.image = this.block.image_url
     this.resize()
   },
   methods :{
@@ -523,6 +558,18 @@ export default {
         this.blockEdit.block.transportations[i].index = i
       }
       this.transportationsIndex = this.blockEdit.block.transportations.length
+    },
+    deleteImage() {
+      if (this.previewImage) {
+        this.previewImage = ''
+        this.blockEdit.uploadImage = ''
+        this.isVisibleFileInput = false
+        this.$nextTick(() => (this.isVisibleFileInput = true))
+      } else {
+        this.$axios.delete(`blocks/${this.block.id}/delete_image`)
+          .catch(err => console.log(err.response))
+        this.image = ''
+      }
     },
     resize(){
       this.height = 'auto'
@@ -636,6 +683,10 @@ export default {
   color: gray;
 }
 
+.file-input {
+  width: 85%;
+}
+
 .file-button {
   display: inline-block;
   background-color: #fff;
@@ -670,5 +721,15 @@ export default {
   width: 100%;
   border-radius: 4px;
   cursor: pointer;
+}
+
+.icon {
+  color: gray;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.icon:hover {
+  color: #383838;
 }
 </style>

--- a/app/javascript/pages/article/components/createdetail/blocklist/BlockItem.vue
+++ b/app/javascript/pages/article/components/createdetail/blocklist/BlockItem.vue
@@ -173,6 +173,5 @@ export default {
 .image {
   width: 100%;
   border-radius: 4px;
-  cursor: pointer;
 }
 </style>

--- a/app/javascript/pages/article/components/createdetail/overview/EditOverview.vue
+++ b/app/javascript/pages/article/components/createdetail/overview/EditOverview.vue
@@ -130,31 +130,49 @@
         v-slot="{ errors }"
         ref="provider"
         name="アイキャッチ"
-        rules="image"
+        rules="image|size:5242.88"
       >
         <h5 class="col-12 mt-4 mb-2 p-1 text-center text-white font-weight-bold article-title word-break">
           アイキャッチ
         </h5>
         <template v-if="previewEyecatch">
-          <div class="mb-2 image-trim">
-            <img :src="previewEyecatch">
+          <div class="mb-1 image-trim">
+            <img
+              :src="previewEyecatch"
+              id="preview-eyecatch"
+            >
           </div>
         </template>
         <template v-else>
-          <template v-if="article.eyecatch_url">
-            <div class="mb-2 image-trim">
-              <img :src="article.eyecatch_url">
+          <template v-if="eyecatch">
+            <div class="mb-1 image-trim">
+              <img :src="eyecatch">
             </div>
           </template>
+        </template>
+        <template v-if="previewEyecatch || eyecatch">
+          <div class="text-center">
+            <div
+              @click="deleteEyecatch"
+              id="delete-btn"
+              class="d-inline-block mb-2 icon"
+            >
+              <font-awesome-icon
+                :icon="['far', 'times-circle']"
+                class="fa-lg"
+              />
+            </div>
+          </div>
         </template>
 
         <template v-if="$mq == 'xs'">
           <div class="text-center">
             <label>
-              <p class="mb-0 pl-3 pr-3 bg-white text-dark file-button">
+              <p class="mb-0 pl-3 pr-3 file-button">
                 画像を選択
               </p>
               <input
+                v-if="isVisibleFileInput"
                 id="eyecatch"
                 type="file"
                 accept="image/png,image/jpeg"
@@ -167,6 +185,7 @@
         </template>
         <template v-else>
           <input
+            v-if="isVisibleFileInput"
             id="eyecatch"
             type="file"
             accept="image/png,image/jpeg"
@@ -175,7 +194,9 @@
             @change="handleChange"
           >
         </template>
-        <span class="text-danger">{{ errors[0] }}</span>
+        <p class="text-center text-danger">
+          {{ errors[0] }}
+        </p>
       </ValidationProvider>
 
       <h5 class="col-12 mt-4 p-1 text-center text-white font-weight-bold article-title word-break">
@@ -259,7 +280,9 @@ export default {
       },
       height: '',
       previewEyecatch: '',
-      uploadEyecatch: ''
+      uploadEyecatch: '',
+      eyecatch: '',
+      isVisibleFileInput: true
     }
   },
   computed: {
@@ -316,6 +339,7 @@ export default {
     for (let article_tag of this.articleEdit.article_tags) {
       this.tags.push(article_tag.tag.name)
     }
+    if (this.articleEdit.eyecatch_url) this.eyecatch = this.article.eyecatch_url
     this.resize()
   },
   methods:{
@@ -417,6 +441,18 @@ export default {
         })
         .catch(err => console.log(err.response))
     },
+    deleteEyecatch() {
+      if (this.previewEyecatch) {
+        this.previewEyecatch = ''
+        this.uploadEyecatch = ''
+        this.isVisibleFileInput = false
+        this.$nextTick(() => (this.isVisibleFileInput = true))
+      } else {
+        this.$axios.delete(`articles/${this.$route.query.id}/delete_eyecatch`)
+          .catch(err => console.log(err.response))
+        this.eyecatch = ''
+      }
+    },
     resize(){
       this.height = 'auto'
       this.$nextTick(()=>{
@@ -479,13 +515,38 @@ export default {
   background-color: #f8f9fa;
 }
 
+.file-input {
+  width: 75%;
+}
+
 .file-button {
+  display: inline-block;
+  background-color: #fff;
   border: solid thin rgb(206, 212, 218);
+  padding: 2px 25px;
+  text-align: center;
+  cursor: pointer;
   border-radius: 20px;
 }
 
-.file-input {
-  width: 75%;
+.file-button:hover {
+  background-color: rgb(206, 212, 218);
+  position: relative;
+}
+
+.file-button-mobile {
+  display: inline-block;
+  background-color: #fff;
+  border: solid thin rgb(206, 212, 218);
+  padding: 2px 25px;
+  text-align: center;
+  cursor: pointer;
+  border-radius: 20px;
+}
+
+.file-button-mobile:active {
+  background-color: rgb(206, 212, 218);
+  position: relative;
 }
 
 .image-trim {
@@ -503,5 +564,15 @@ export default {
   height: 100%;
   object-fit: cover;
   border-radius: 4px;
+}
+
+.icon {
+  color: gray;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.icon:hover {
+  color: #383838;
 }
 </style>

--- a/app/javascript/pages/article/components/createoverview/OverviewForm.vue
+++ b/app/javascript/pages/article/components/createoverview/OverviewForm.vue
@@ -214,7 +214,7 @@
             v-slot="{ errors }"
             ref="provider"
             name="アイキャッチ"
-            rules="image"
+            rules="image|size:5242.88"
           >
             <h5
               id="アイキャッチ"
@@ -223,11 +223,26 @@
               アイキャッチ
             </h5>
             <template v-if="previewEyecatch">
-              <div class="mb-2 image-trim">
-                <img :src="previewEyecatch">
+              <div class="mb-1 image-trim">
+                <img
+                  :src="previewEyecatch"
+                  id="preview-eyecatch"
+                >
+              </div>
+              <div class="text-center">
+                <div
+                  @click="deleteEyecatch"
+                  class="d-inline-block mb-2 icon"
+                >
+                  <font-awesome-icon
+                    :icon="['far', 'times-circle']"
+                    class="fa-lg"
+                  />
+                </div>
               </div>
             </template>
             <input
+              v-if="isVisibleFileInput"
               id="eyecatch"
               type="file"
               accept="image/png,image/jpeg"
@@ -235,7 +250,9 @@
               class="form-control-file mx-auto file-input"
               @change="handleChange"
             >
-            <span class="text-danger">{{ errors[0] }}</span>
+            <p class="text-center text-danger">
+              {{ errors[0] }}
+            </p>
           </ValidationProvider>
         </div>
 
@@ -264,7 +281,10 @@
           >
           <p class="mb-0 text-center text-secondary font-small">
             ※Google My MapsのHTMLを入力することで地図を埋め込むことができます。詳しくは
-            <a @click="showModal" href="#">こちら</a>。
+            <a
+              href="#"
+              @click="showModal"
+            >こちら</a>。
           </p>
         </div>
 
@@ -355,7 +375,8 @@ export default {
       height: '',
       previewEyecatch: '',
       uploadEyecatch: '',
-      isMobile: isMobile,
+      isVisibleFileInput: true,
+      isMobile: isMobile
     }
   },
   computed: {
@@ -519,6 +540,12 @@ export default {
     showModal() {
       this.$refs.modal.showModal()
     },
+    deleteEyecatch() {
+      this.previewEyecatch = ''
+      this.uploadEyecatch = ''
+      this.isVisibleFileInput = false
+      this.$nextTick(() => (this.isVisibleFileInput = true))
+    },
     resize(){
       this.height = 'auto'
       this.$nextTick(()=>{
@@ -653,5 +680,15 @@ export default {
 
 .pointer {
   cursor: pointer;
+}
+
+.icon {
+  color: gray;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.icon:hover {
+  color: #383838;
 }
 </style>

--- a/app/javascript/pages/article/components/createoverview/OverviewFormSmall.vue
+++ b/app/javascript/pages/article/components/createoverview/OverviewFormSmall.vue
@@ -203,7 +203,7 @@
             v-slot="{ errors }"
             ref="provider"
             name="アイキャッチ"
-            rules="image"
+            rules="image|size:5242.88"
           >
             <h5
               id="アイキャッチ"
@@ -212,8 +212,19 @@
               アイキャッチ
             </h5>
             <template v-if="previewEyecatch">
-              <div class="mb-2 image-trim">
+              <div class="mb-1 image-trim">
                 <img :src="previewEyecatch">
+              </div>
+              <div class="text-center">
+                <div
+                  class="d-inline-block mb-2 icon"
+                  @click="deleteEyecatch"
+                >
+                  <font-awesome-icon
+                    :icon="['far', 'times-circle']"
+                    class="fa-lg"
+                  />
+                </div>
               </div>
             </template>
             <label>
@@ -228,6 +239,7 @@
                 </p>
               </template>
               <input
+                v-if="isVisibleFileInput"
                 id="eyecatch"
                 type="file"
                 accept="image/png,image/jpeg"
@@ -236,7 +248,9 @@
                 @change="handleChange"
               >
             </label>
-            <span class="text-danger">{{ errors[0] }}</span>
+            <p class="text-center text-danger">
+              {{ errors[0] }}
+            </p>
           </ValidationProvider>
         </div>
 
@@ -267,7 +281,10 @@
           >
           <p class="mb-0 text-center text-secondary font-small">
             ※Google My MapsのHTMLを入力することで地図を埋め込むことができます。詳しくは
-            <a @click="showModal" href="#">こちら</a>。
+            <a
+              href="#"
+              @click="showModal"
+            >こちら</a>。
           </p>
         </div>
 
@@ -356,6 +373,7 @@ export default {
       height: '',
       previewEyecatch: '',
       uploadEyecatch: '',
+      isVisibleFileInput: true,
       isMobile: isMobile
     }
   },
@@ -521,6 +539,12 @@ export default {
     showModal() {
       this.$refs.modal.showModal()
     },
+    deleteEyecatch() {
+      this.previewEyecatch = ''
+      this.uploadEyecatch = ''
+      this.isVisibleFileInput = false
+      this.$nextTick(() => (this.isVisibleFileInput = true))
+    },
     resize(){
       this.height = 'auto'
       this.$nextTick(()=>{
@@ -667,5 +691,15 @@ export default {
 
 .pointer {
   cursor: pointer;
+}
+
+.icon {
+  color: gray;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.icon:hover {
+  color: #383838;
 }
 </style>

--- a/app/javascript/pages/article/components/createoverview/form/HowToEmbedMap.vue
+++ b/app/javascript/pages/article/components/createoverview/form/HowToEmbedMap.vue
@@ -2,7 +2,11 @@
   <div>
     <template v-if="$mq == 'xs'">
       <modal
-        name="how-to-embed-map" :scrollable="true" width="90%" :maxHeight="300" height="auto"
+        name="how-to-embed-map"
+        :scrollable="true"
+        width="90%"
+        :max-height="300"
+        height="auto"
         class="modal-box-xs text-center text-dark"
       >
         <div class="modal-header">
@@ -13,7 +17,10 @@
         <div class="modal-body">
           <p class="m-0 font-small">
             ①「Google My Maps」の
-            <a href="https://www.google.com/maps/d/u/0/?hl=ja" target="_blank">
+            <a
+              href="https://www.google.com/maps/d/u/0/?hl=ja"
+              target="_blank"
+            >
               マイマップ一覧ページ
             </a>
             にアクセスしてください
@@ -68,8 +75,8 @@
           </p>
 
           <div
-            @click="hideModal"
             class="mt-5 text-center button"
+            @click="hideModal"
           >
             閉じる
           </div>
@@ -78,7 +85,10 @@
     </template>
     <template v-else>
       <modal
-        name="how-to-embed-map" :scrollable="true" :maxHeight="300" height="auto"
+        name="how-to-embed-map"
+        :scrollable="true"
+        :max-height="300"
+        height="auto"
         class="modal-box text-center text-dark"
       >
         <div class="modal-header">
@@ -89,7 +99,10 @@
         <div class="modal-body">
           <p class="m-0">
             ①「Google My Maps」の
-            <a href="https://www.google.com/maps/d/u/0/?hl=ja" target="_blank">
+            <a
+              href="https://www.google.com/maps/d/u/0/?hl=ja"
+              target="_blank"
+            >
               マイマップ一覧ページ
             </a>
             にアクセスしてください
@@ -144,8 +157,8 @@
           </p>
 
           <div
-            @click="hideModal"
             class="mt-5 text-center button"
+            @click="hideModal"
           >
             閉じる
           </div>

--- a/app/javascript/pages/article/components/index/ArticleItem.vue
+++ b/app/javascript/pages/article/components/index/ArticleItem.vue
@@ -250,8 +250,8 @@
                 <div class="mt-1 mb-1 text-center">
                   <div
                     v-for="article_tag in article.article_tags"
-                    :key="article_tag.id"
                     :id="'tag-' + article_tag.tag.name"
+                    :key="article_tag.id"
                     class="d-inline-block pl-1 pr-1 text-primary article-tag"
                   >
                     <template v-if="$mq == 'lg'">

--- a/app/javascript/pages/article/components/show/Overview.vue
+++ b/app/javascript/pages/article/components/show/Overview.vue
@@ -314,8 +314,8 @@
       <div class="col-12 mb-2 p-0 text-muted text-center word-break article-info">
         <p
           v-for="article_tag in article.article_tags"
-          :key="article_tag.id"
           :id="'tag-' + article_tag.tag.name"
+          :key="article_tag.id"
           class="d-inline-block m-0 pl-1 pr-1 article-tag"
         >
           <template v-if="$mq == 'lg'">

--- a/app/javascript/pages/article/index.vue
+++ b/app/javascript/pages/article/index.vue
@@ -1,94 +1,162 @@
 <template>
-  <div class="container-fluid mt-2">
-    <template v-if="$mq == 'lg'">
-      <div class="row">
-        <div
-          v-show="isVisibleMsg"
-          class="col-12 text-white msg"
-        >
-          {{ msg }}
-        </div>
-        <template v-if="articles.length">
-          <div class="col-8 mb-5">
-            <div
-              v-for="article in articles"
-              :key="article.id"
-            >
-              <ArticleList
-                :article="article"
-                @searchByTag="searchByTag"
+  <div>
+    <div
+      v-show="isVisibleMsg"
+      class="col-12 mt-2 text-white msg"
+    >
+      {{ msg }}
+    </div>
+    <div class="container-fluid mt-2">
+      <template v-if="$mq == 'lg'">
+        <div class="row">
+          <template v-if="articles.length">
+            <div class="col-8 mb-5">
+              <div
+                v-for="article in articles"
+                :key="article.id"
+              >
+                <ArticleList
+                  :article="article"
+                  @searchByTag="searchByTag"
+                />
+              </div>
+              <infinite-loading
+                spinner="circles"
+                @infinite="infiniteHandler"
               />
             </div>
-            <infinite-loading
-              spinner="circles"
-              @infinite="infiniteHandler"
-            />
-          </div>
-        </template>
-
-        <template v-else>
-          <template v-if="loading">
-            <vue-loading
-              type="spiningDubbles"
-              color="#FF58F2"
-              :size="{ width: '100px' }"
-              class="mt-4 pt-5"
-            />
           </template>
+
           <template v-else>
-            <div class="col-8 mt-5 pt-5 mb-5">
-              <h3 class="text-center font-weight-bold text-secondary">
-                投稿がありません
-              </h3>
-            </div>
+            <template v-if="loading">
+              <vue-loading
+                type="spiningDubbles"
+                color="#FF58F2"
+                :size="{ width: '100px' }"
+                class="mt-4 pt-5"
+              />
+            </template>
+            <template v-else>
+              <div class="col-8 mt-5 pt-5 mb-5">
+                <h3 class="text-center font-weight-bold text-secondary">
+                  投稿がありません
+                </h3>
+              </div>
+            </template>
           </template>
-        </template>
-        <SearchForm
-          ref="form"
-          :article="presence"
-          :loading="loading"
-          :sentag="sentag"
-          :japan="japan"
-          class="col-4"
-          @resetPageJapan="resetPageJapan"
-          @resetPageWorld="resetPageWorld"
-          @setSearch="setSearch"
-        />
-      </div>
-    </template>
-
-    <template v-else-if="$mq == 'sm'">
-      <div class="row">
-        <div class="col-12 search-form">
-          <AreaChanger
+          <SearchForm
+            ref="form"
             :article="presence"
             :loading="loading"
-            class="ml-5 mr-5 pl-5 pr-5"
+            :sentag="sentag"
+            :japan="japan"
+            class="col-4"
             @resetPageJapan="resetPageJapan"
             @resetPageWorld="resetPageWorld"
             @setSearch="setSearch"
           />
         </div>
-        <div class="col-12 mb-5">
-          <template v-if="articles.length">
-            <div
-              v-for="article in articles"
-              :key="article.id"
+      </template>
+
+      <template v-else-if="$mq == 'sm'">
+        <div class="row">
+          <div class="col-12 search-form">
+            <AreaChanger
+              :article="presence"
+              :loading="loading"
               class="ml-5 mr-5 pl-5 pr-5"
-            >
-              <ArticleList
-                :article="article"
-              />
-            </div>
-            <infinite-loading
-              spinner="circles"
-              @infinite="infiniteHandler"
+              @resetPageJapan="resetPageJapan"
+              @resetPageWorld="resetPageWorld"
+              @setSearch="setSearch"
             />
+          </div>
+          <div class="col-12 mb-5">
+            <template v-if="articles.length">
+              <div
+                v-for="article in articles"
+                :key="article.id"
+                class="ml-5 mr-5 pl-5 pr-5"
+              >
+                <ArticleList
+                  :article="article"
+                />
+              </div>
+              <infinite-loading
+                spinner="circles"
+                @infinite="infiniteHandler"
+              />
+            </template>
+
+            <template v-else>
+              <template v-if="loading">
+                <div class="mt-5 mb-5">
+                  <vue-loading
+                    type="spiningDubbles"
+                    color="#FF58F2"
+                    :size="{ width: '80px' }"
+                  />
+                </div>
+              </template>
+
+              <template v-else>
+                <div class="mt-5 pt-3 mb-5">
+                  <h3 class="text-center font-weight-bold text-secondary">
+                    投稿がありません
+                  </h3>
+                </div>
+              </template>
+            </template>
+          </div>
+        </div>
+      </template>
+
+      <template v-else>
+        <div class="row">
+          <div class="col-12">
+            <template v-if="authUser">
+              <AreaChanger
+                :article="presence"
+                :loading="loading"
+                class="mb-4 search-form"
+                @resetPageJapan="resetPageJapan"
+                @resetPageWorld="resetPageWorld"
+                @setSearch="setSearch"
+              />
+            </template>
+            <template v-else>
+              <AreaChanger
+                :article="presence"
+                :loading="loading"
+                class="mb-3 search-form"
+                @resetPageJapan="resetPageJapan"
+                @resetPageWorld="resetPageWorld"
+                @setSearch="setSearch"
+              />
+            </template>
+          </div>
+          <template v-if="articles.length">
+            <div class="col-12 border-top">
+              <div
+                v-for="article in articles"
+                :key="article.id"
+              >
+                <ArticleList
+                  :article="article"
+                />
+              </div>
+              <template v-if="page <= kaminariPage">
+                <infinite-loading
+                  spinner="circles"
+                  class="mb-4"
+                  @infinite="infiniteHandler"
+                />
+              </template>
+            </div>
           </template>
 
           <template v-else>
             <template v-if="loading">
-              <div class="mt-5 mb-5">
+              <div class="col-12 mt-3">
                 <vue-loading
                   type="spiningDubbles"
                   color="#FF58F2"
@@ -98,7 +166,7 @@
             </template>
 
             <template v-else>
-              <div class="mt-5 pt-3 mb-5">
+              <div class="col-12 mt-4 pt-2">
                 <h3 class="text-center font-weight-bold text-secondary">
                   投稿がありません
                 </h3>
@@ -106,74 +174,8 @@
             </template>
           </template>
         </div>
-      </div>
-    </template>
-
-    <template v-else>
-      <div class="row">
-        <div class="col-12">
-          <template v-if="authUser">
-            <AreaChanger
-              :article="presence"
-              :loading="loading"
-              class="mb-4 search-form"
-              @resetPageJapan="resetPageJapan"
-              @resetPageWorld="resetPageWorld"
-              @setSearch="setSearch"
-            />
-          </template>
-          <template v-else>
-            <AreaChanger
-              :article="presence"
-              :loading="loading"
-              class="mb-3 search-form"
-              @resetPageJapan="resetPageJapan"
-              @resetPageWorld="resetPageWorld"
-              @setSearch="setSearch"
-            />
-          </template>
-        </div>
-        <template v-if="articles.length">
-          <div class="col-12 border-top">
-            <div
-              v-for="article in articles"
-              :key="article.id"
-            >
-              <ArticleList
-                :article="article"
-              />
-            </div>
-            <template v-if="page <= kaminariPage">
-              <infinite-loading
-                spinner="circles"
-                class="mb-4"
-                @infinite="infiniteHandler"
-              />
-            </template>
-          </div>
-        </template>
-
-        <template v-else>
-          <template v-if="loading">
-            <div class="col-12 mt-3">
-              <vue-loading
-                type="spiningDubbles"
-                color="#FF58F2"
-                :size="{ width: '80px' }"
-              />
-            </div>
-          </template>
-
-          <template v-else>
-            <div class="col-12 mt-4 pt-2">
-              <h3 class="text-center font-weight-bold text-secondary">
-                投稿がありません
-              </h3>
-            </div>
-          </template>
-        </template>
-      </div>
-    </template>
+      </template>
+    </div>
   </div>
 </template>
 

--- a/app/javascript/pages/register/register.vue
+++ b/app/javascript/pages/register/register.vue
@@ -96,10 +96,23 @@
                 >
                   <div class="d-flex justify-content-center align-items-center">
                     <template v-if="previewAvatar">
-                      <img
-                        :src="previewAvatar"
-                        class="user-icon"
-                      >
+                      <div>
+                        <img
+                          :src="previewAvatar"
+                          class="user-icon"
+                        >
+                        <div class="mt-2 text-center">
+                          <div
+                            class="d-inline-block icon"
+                            @click="deleteAvatar"
+                          >
+                            <font-awesome-icon
+                              :icon="['far', 'times-circle']"
+                              class="fa-lg"
+                            />
+                          </div>
+                        </div>
+                      </div>
                     </template>
                     <template v-else>
                       <img
@@ -121,11 +134,19 @@
                           </p>
                         </template>
                         <template v-else>
-                          <p class="mb-0 pl-3 pr-3 text-dark file-button">
-                            画像を選択
-                          </p>
+                          <template v-if="previewAvatar">
+                            <p class="pl-3 pr-3 text-dark file-button file-margin">
+                              画像を選択
+                            </p>
+                          </template>
+                          <template v-else>
+                            <p class="mb-0 pl-3 pr-3 text-dark file-button">
+                              画像を選択
+                            </p>
+                          </template>
                         </template>
                         <input
+                          v-if="isVisibleFileInput"
                           id="avatar"
                           type="file"
                           accept="image/png,image/jpeg"
@@ -255,7 +276,7 @@
                   v-slot="{ errors }"
                   ref="provider"
                   name="プロフィール画像"
-                  rules="image"
+                  rules="image|size:5242.88"
                 >
                   <p
                     id="プロフィール画像"
@@ -266,16 +287,30 @@
                   <template v-if="previewAvatar">
                     <img
                       :src="previewAvatar"
-                      class="mb-3 user-icon"
+                      id="preview-avatar"
+                      class="mb-2 user-icon"
                     >
+                    <div class="mb-3 text-center">
+                      <div
+                        class="d-inline-block icon"
+                        @click="deleteAvatar"
+                      >
+                        <font-awesome-icon
+                          :icon="['far', 'times-circle']"
+                          class="fa-lg"
+                        />
+                      </div>
+                    </div>
                   </template>
                   <template v-else>
                     <img
                       src="~default.jpg"
+                      id="default-avatar"
                       class="mb-3 user-icon"
                     >
                   </template>
                   <input
+                    v-if="isVisibleFileInput"
                     id="avatar"
                     type="file"
                     accept="image/png,image/jpeg"
@@ -339,6 +374,7 @@ export default {
       previewAvatar: '',
       emailError: false,
       inputType: 'password',
+      isVisibleFileInput: true,
       isMobile: isMobile
     }
   },
@@ -378,6 +414,12 @@ export default {
     },
     hidePassword() {
       this.inputType = 'password'
+    },
+    deleteAvatar() {
+      this.uploadAvatar = ''
+      this.previewAvatar = ''
+      this.isVisibleFileInput = false
+      this.$nextTick(() => (this.isVisibleFileInput = true))
     }
   }
 }
@@ -484,5 +526,19 @@ export default {
 	height: 100px;
 	object-fit: cover;
 	border-radius: 50%;
+}
+
+.icon {
+  color: gray;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.icon:hover {
+  color: #383838;
+}
+
+.file-margin {
+  margin-bottom: 35px;
 }
 </style>

--- a/app/javascript/pages/session/login.vue
+++ b/app/javascript/pages/session/login.vue
@@ -51,7 +51,10 @@
                       </span>
                     </template>
                     <template v-else>
-                      <span @click="hidePassword">
+                      <span
+                        class="pointer"
+                        @click="hidePassword"
+                      >
                         <font-awesome-icon
                           :icon="['far', 'eye-slash']"
                           class="fa-lg"
@@ -144,7 +147,10 @@
                       </span>
                     </template>
                     <template v-else>
-                      <span @click="hidePassword">
+                      <span
+                        class="pointer"
+                        @click="hidePassword"
+                      >
                         <font-awesome-icon
                           :icon="['far', 'eye-slash']"
                           class="fa-lg"
@@ -298,5 +304,10 @@ export default {
 
 .eye-icon {
   width: 26.66px;
+  cursor: pointer;
+}
+
+.pointer {
+  cursor: pointer;
 }
 </style>

--- a/app/javascript/pages/top/top.vue
+++ b/app/javascript/pages/top/top.vue
@@ -23,40 +23,40 @@
         <div class="mt-5 pt-3 mb-5">
           <template v-if="isMobile">
             <h5
-              @click="toRegister"
               class="w-100 mb-3 pt-2 pb-2 text-white text-center font-weight-bold register-btn-mobile"
+              @click="toRegister"
             >
               ユーザー登録
             </h5>
             <h5
-              @click="toLogin"
               class="w-100 mb-3 pt-2 pb-2 text-white text-center font-weight-bold login-btn-mobile"
+              @click="toLogin"
             >
               ログイン
             </h5>
             <h5
-              @click="toArticles"
               class="w-100 mb-3 pt-2 pb-2 text-white text-center font-weight-bold articles-btn-mobile"
+              @click="toArticles"
             >
               投稿一覧
             </h5>
           </template>
           <template v-else>
             <h5
-              @click="toRegister"
               class="w-100 pt-2 pb-2 text-white text-center font-weight-bold register-btn"
+              @click="toRegister"
             >
               ユーザー登録
             </h5>
             <h5
-              @click="toLogin"
               class="w-100 mr-2 pt-2 pb-2 text-white text-center font-weight-bold login-btn"
+              @click="toLogin"
             >
               ログイン
             </h5>
             <h5
-              @click="toArticles"
               class="w-100 pt-2 pb-2 text-white text-center font-weight-bold articles-btn"
+              @click="toArticles"
             >
               投稿一覧
             </h5>
@@ -88,7 +88,9 @@
             class="sample-image"
           >
         </div>
-        <p class="p-0 m-0 font-weight-bold text-center">・<br>・<br>・</p>
+        <p class="p-0 m-0 font-weight-bold text-center">
+          ・<br>・<br>・
+        </p>
         <div class="mb-3 ml-5 mr-5 d-flex justify-content-center image-trim-sm">
           <img
             src="~sample-sm3.jpg"
@@ -105,7 +107,9 @@
             class="sample-image"
           >
         </div>
-        <p class="p-0 m-0 font-weight-bold text-center">・<br>・<br>・</p>
+        <p class="p-0 m-0 font-weight-bold text-center">
+          ・<br>・<br>・
+        </p>
         <div class="mb-3 ml-5 mr-5 d-flex justify-content-center image-trim-sm">
           <img
             src="~sample-sm5.jpg"
@@ -129,8 +133,8 @@
 
         <div class="mt-5 mb-5 pb-3 d-flex justify-content-center">
           <h5
-            @click="toRegister"
             class="p-2 m-0 text-white text-center font-weight-bold register-btn"
+            @click="toRegister"
           >
             今すぐ始める
           </h5>
@@ -159,40 +163,40 @@
         >
           <template v-if="isMobile">
             <h5
-              @click="toRegister"
               class="mr-2 pt-2 pb-2 text-white text-center font-weight-bold register-btn-mobile"
+              @click="toRegister"
             >
               ユーザー登録
             </h5>
             <h5
-              @click="toLogin"
               class="ml-2 mr-2 pt-2 pb-2 text-white text-center font-weight-bold login-btn-mobile"
+              @click="toLogin"
             >
               ログイン
             </h5>
             <h5
-              @click="toArticles"
               class="ml-2 pt-2 pb-2 text-white text-center font-weight-bold articles-btn-mobile"
+              @click="toArticles"
             >
               投稿一覧
             </h5>
           </template>
           <template v-else>
             <h5
-              @click="toRegister"
               class="mr-2 pt-2 pb-2 text-white text-center font-weight-bold register-btn"
+              @click="toRegister"
             >
               ユーザー登録
             </h5>
             <h5
-              @click="toLogin"
               class="ml-2 mr-2 pt-2 pb-2 text-white text-center font-weight-bold login-btn"
+              @click="toLogin"
             >
               ログイン
             </h5>
             <h5
-              @click="toArticles"
               class="ml-2 pt-2 pb-2 text-white text-center font-weight-bold articles-btn"
+              @click="toArticles"
             >
               投稿一覧
             </h5>
@@ -251,8 +255,8 @@
           class="mt-5 mb-5 pt-1 pb-3 d-flex justify-content-center"
         >
           <h5
-            @click="toRegister"
             class="p-2 m-0 text-white text-center font-weight-bold register-btn"
+            @click="toRegister"
           >
             今すぐ始める
           </h5>

--- a/app/javascript/pages/user/editmypage.vue
+++ b/app/javascript/pages/user/editmypage.vue
@@ -14,7 +14,7 @@
                 v-slot="{ errors }"
                 ref="provider"
                 name="プロフィール画像"
-                rules="image"
+                rules="image|size:5242.88"
               >
                 <h5
                   id="プロフィール画像"
@@ -22,38 +22,78 @@
                 >
                   プロフィール画像
                 </h5>
-                <template v-if="uploadAvatar">
-                  <img
-                    :src="previewAvatar"
-                    class="user-icon"
-                  >
-                </template>
-                <template v-else>
-                  <img
-                    :src="user.avatar_url"
-                    class="user-icon"
-                  >
-                </template>
-                <label class="mb-0 ml-3 mr-3">
-                  <template v-if="isMobile">
-                    <p class="mb-0 pl-3 pr-3 text-dark file-button-mobile">
-                      画像を選択
-                    </p>
-                  </template>
-                  <template v-else>
-                    <p class="mb-0 pl-3 pr-3 text-dark file-button">
-                      画像を選択
-                    </p>
-                  </template>
-                  <input
-                    id="avatar"
-                    type="file"
-                    accept="image/png,image/jpeg"
-                    name="プロフィール画像"
-                    class="d-none"
-                    @change="handleChange"
-                  >
-                </label>
+                <div class="d-flex justify-content-center align-items-center">
+                  <div>
+                    <template v-if="uploadAvatar">
+                      <img
+                        :src="previewAvatar"
+                        class="user-icon"
+                      >
+                    </template>
+                    <template v-else>
+                      <template v-if="avatar">
+                        <img
+                          :src="avatar"
+                          class="user-icon"
+                        >
+                      </template>
+                      <template v-else>
+                        <img
+                          src="~default.jpg"
+                          class="user-icon"
+                        >
+                      </template>
+                    </template>
+                    <template v-if="uploadAvatar || avatar">
+                      <div>
+                        <div
+                          class="mt-2 d-inline-block icon"
+                          @click="resetAvatar"
+                        >
+                          <font-awesome-icon
+                            :icon="['far', 'times-circle']"
+                            class="fa-lg"
+                          />
+                        </div>
+                      </div>
+                    </template>
+                  </div>
+                  <label class="mb-0 ml-3 mr-3">
+                    <template v-if="isMobile">
+                      <template v-if="uploadAvatar || avatar">
+                        <p class="pl-3 pr-3 text-dark file-button-mobile file-margin">
+                          画像を選択
+                        </p>
+                      </template>
+                      <template v-else>
+                        <p class="mb-0 pl-3 pr-3 text-dark file-button-mobile">
+                          画像を選択
+                        </p>
+                      </template>
+                    </template>
+                    <template v-else>
+                      <template v-if="uploadAvatar || avatar">
+                        <p class="pl-3 pr-3 text-dark file-button file-margin">
+                          画像を選択
+                        </p>
+                      </template>
+                      <template v-else>
+                        <p class="mb-0 pl-3 pr-3 text-dark file-button">
+                          画像を選択
+                        </p>
+                      </template>
+                    </template>
+                    <input
+                      v-if="isVisibleFileInput"
+                      id="avatar"
+                      type="file"
+                      accept="image/png,image/jpeg"
+                      name="プロフィール画像"
+                      class="d-none"
+                      @change="handleChange"
+                    >
+                  </label>
+                </div>
                 <span class="text-danger">{{ errors[0] }}</span>
               </ValidationProvider>
             </div>
@@ -136,7 +176,7 @@
                 v-slot="{ errors }"
                 ref="provider"
                 name="プロフィール画像"
-                rules="image"
+                rules="image|size:5242.88"
               >
                 <h5
                   id="プロフィール画像"
@@ -147,21 +187,45 @@
                 <template v-if="uploadAvatar">
                   <img
                     :src="previewAvatar"
-                    class="mt-2 mb-3 user-icon"
+                    id="preview-avatar"
+                    class="mt-2 mb-2 user-icon"
                   >
                 </template>
                 <template v-else>
-                  <img
-                    :src="user.avatar_url"
-                    class="mt-2 mb-3 user-icon"
-                  >
+                  <template v-if="avatar">
+                    <img
+                      :src="avatar"
+                      class="mt-2 mb-2 user-icon"
+                    >
+                  </template>
+                  <template v-else>
+                    <img
+                      src="~default.jpg"
+                      id="default-avatar"
+                      class="mt-2 mb-2 user-icon"
+                    >
+                  </template>
+                </template>
+                <template v-if="uploadAvatar || avatar">
+                  <div>
+                    <div
+                      class="d-inline-block icon"
+                      @click="resetAvatar"
+                    >
+                      <font-awesome-icon
+                        :icon="['far', 'times-circle']"
+                        class="fa-lg"
+                      />
+                    </div>
+                  </div>
                 </template>
                 <input
+                  v-if="isVisibleFileInput"
                   id="avatar"
                   type="file"
                   accept="image/png,image/jpeg"
                   name="プロフィール画像"
-                  class="form-control-file mx-auto file-input"
+                  class="mt-3 form-control-file mx-auto file-input"
                   @change="handleChange"
                 >
                 <span class="text-danger">{{ errors[0] }}</span>
@@ -239,6 +303,7 @@
 </template>
 
 <script>
+import 'default.jpg'
 import TermAndPolicyLink from '../../components/TermAndPolicyLink'
 import { mapGetters, mapActions } from 'vuex'
 import { isMobile } from 'mobile-device-detect'
@@ -258,7 +323,10 @@ export default {
       height: '',
       previewAvatar: '',
       uploadAvatar: '',
+      avatar: '',
+      isVisibleFileInput: true,
       isMobile: isMobile
+
     }
   },
   computed: {
@@ -278,6 +346,7 @@ export default {
   },
   created() {
     this.user = Object.assign({}, this.authUser)
+    this.getAvatarUrl()
     this.resize()
   },
   methods: {
@@ -308,6 +377,25 @@ export default {
         .catch(err => console.log(err.response))
       this.$router.push({ name: 'MyPage' })
     },
+    getAvatarUrl() {
+      let avatar = this.authUser.avatar_url.split('/')
+      let avatar_url = avatar.slice(-1)[0]
+      if (avatar_url != 'default-image.jpg') {
+        this.avatar = this.authUser.avatar_url
+      }
+    },
+    resetAvatar() {
+      if (this.previewAvatar) {
+        this.previewAvatar = ''
+        this.uploadAvatar = ''
+        this.isVisibleFileInput = false
+        this.$nextTick(() => (this.isVisibleFileInput = true))
+      } else {
+        this.$axios.patch(`users/${this.authUser.id}/reset_avatar`)
+          .catch(err => console.log(err.response))
+        this.avatar = ''
+      }
+    }
   }
 }
 </script>
@@ -409,5 +497,19 @@ export default {
 .file-button-mobile:active {
   background-color: rgb(206, 212, 218);
   position: relative;
+}
+
+.icon {
+  color: gray;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.icon:hover {
+  color: #383838;
+}
+
+.file-margin {
+  margin-bottom: 35px;
 }
 </style>

--- a/app/javascript/plugins/veevalidate.js
+++ b/app/javascript/plugins/veevalidate.js
@@ -10,7 +10,8 @@ import {
   email,
   required,
   numeric,
-  image
+  image,
+  size
 } from 'vee-validate/dist/rules';
 
 Vue.component('ValidationObserver', ValidationObserver)
@@ -54,6 +55,11 @@ extend('numeric', {
 extend('image', {
   ...image,
   message: '{_field_}は画像形式で入力してください'
+})
+
+extend('size', {
+  ...size,
+  message: '{_field_}は5MB以下にしてください'
 })
 
 extend('max', {

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -19,7 +19,7 @@ class Article < ApplicationRecord
   validates :description, length: { maximum: 500 }
   validates :map, length: { maximum: 300 }
   validates :status, presence: true
-  validates :eyecatch, blob: { content_type: ['image/png', 'image/jpg', 'image/jpeg'], size_range: 0..5.megabytes }
+  validates :eyecatch, attachment: { content_type: %r{\Aimage/(png|jpeg)\Z}, maximum: 5_242_880 }
 
   enum status: { draft: 0, published: 1 }
 

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -11,7 +11,7 @@ class Block < ApplicationRecord
   validates :place, length: { maximum: 100 }
   validates :place_info, length: { maximum: 500 }
   validates :comment, length: { maximum: 1_000 }
-  validates :image, blob: { content_type: ['image/png', 'image/jpg', 'image/jpeg'], size_range: 0..5.megabytes }
+  validates :image, attachment: { content_type: %r{\Aimage/(png|jpeg)\Z}, maximum: 5_242_880 }
 
   def image_url
     image.attached? ? Rails.application.routes.url_helpers.rails_blob_path(image, only_path: true) : nil

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
 
   before_create :default_avatar
+  before_save :null_to_nill
 
   has_one_attached :avatar
 
@@ -21,7 +22,7 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 30 }
   validates :email, presence: true, uniqueness: true
   validates :description, length: { maximum: 500 }
-  validates :avatar, blob: { content_type: ['image/png', 'image/jpg', 'image/jpeg'], size_range: 0..5.megabytes }
+  validates :avatar, attachment: { content_type: %r{\Aimage/(png|jpeg)\Z}, maximum: 5_242_880 }
 
   def follow(other_user_id)
     return if id == other_user_id
@@ -58,5 +59,13 @@ class User < ApplicationRecord
     return if avatar.attached?
 
     avatar.attach(io: File.open(Rails.root.join('app', 'assets', 'images', 'default.jpg')), filename: 'default-image.jpg', content_type: 'image/png')
+  end
+
+  private
+
+  def null_to_nill
+    return if description != 'null'
+
+    self.description = nil
   end
 end

--- a/app/validators/attachment_validator.rb
+++ b/app/validators/attachment_validator.rb
@@ -1,0 +1,17 @@
+class AttachmentValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank? || !value.attached?
+
+    if options[:maximum]
+      if value.byte_size > options[:maximum]
+        record.errors[attribute] << '5MB以下にしてください'
+      end
+    end
+
+    return unless options[:content_type]
+
+    return if value.content_type.match?(options[:content_type])
+
+    record.errors[attribute] << '画像ファイル形式にしてください'
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
       collection do
         get 'me'
       end
+      member do
+        patch 'reset_avatar'
+      end
     end
     resources :relationships do
       member do
@@ -36,13 +39,18 @@ Rails.application.routes.draw do
         get 'user_articles_draft'
         get 'user_favorites'
         get 'user_articles_count'
+        delete 'delete_eyecatch'
       end
     end
     resources :article_regions, only: %i[create destroy]
     resources :tags, only: %i[create]
     resources :article_tags, only: %i[create destroy]
     resources :days, only: %i[show create destroy]
-    resources :blocks, only: %i[show create update destroy]
+    resources :blocks do
+      member do
+        delete 'delete_image'
+      end
+    end
     resources :spendings, only: %i[create update destroy]
     resources :transportations, only: %i[create update destroy]
     resources :comments, only: %i[show create update destroy]

--- a/spec/system/articles_create_spec.rb
+++ b/spec/system/articles_create_spec.rb
@@ -254,6 +254,24 @@ RSpec.describe "記事作成", type: :system do
       end
     end
 
+    context 'アイキャッチを選択したのちXボタンをクリック' do
+      it 'アイキャッチの選択が解除される' do
+        visit '/create_trip'
+        attach_file('アイキャッチ', 'public/images/sample.png')
+        expect(page).to have_css('#preview-eyecatch')
+        find('.icon').click
+        expect(page).to_not have_css('#preview-eyecatch')
+      end
+    end
+
+    context 'マップの詳しくはこちらをクリック' do
+      it 'マップ埋め込み説明のモーダルが表示さえる' do
+        visit '/create_trip'
+        click_on 'こちら'
+        expect(page).to_not have_content('旅行記録に「Google My Maps」を埋め込む方法')
+      end
+    end
+
     context '必須項目を入力せずに「詳細入力ページへ進む」をクリック' do
       it 'バリデーションメッセージが表示されてページ遷移しない（国内フォーム）' do
         country_japan
@@ -272,14 +290,6 @@ RSpec.describe "記事作成", type: :system do
         expect(page).to have_content('国は必須項目です')
       end
     end
-
-    context 'マップの詳しくはこちらをクリック' do
-      it 'マップ埋め込み説明のモーダルが表示さえる' do
-        visit '/create_trip'
-        click_on 'こちら'
-        expect(page).to_not have_content('旅行記録に「Google My Maps」を埋め込む方法')
-      end
-    end
   end
 
   describe '記事詳細作成画面' do
@@ -288,6 +298,7 @@ RSpec.describe "記事作成", type: :system do
         create_article_japan
         find('.overview').click
       }
+
       context '概要ボタンをクリック' do
         it '記事概要が表示される' do
           expect(page).to have_content('タイトル')
@@ -329,8 +340,9 @@ RSpec.describe "記事作成", type: :system do
       end
 
       context '概要欄の編集ボタンをクリック' do
+        before { find('.edit-button').click }
+
         it '概要編集フォームが表示される' do
-          find('.edit-button').click
           sleep 2
           expect(page).to have_content('タイトル')
           expect(page).to have_content('コメント')
@@ -355,7 +367,6 @@ RSpec.describe "記事作成", type: :system do
 
         context '編集して保存をクリック' do
           it '概要蘭がアップデートされる' do
-            find('.edit-button').click
             fill_in 'タイトル', with: 'UpdatedTitle'
             fill_in 'コメント', with: 'UpdatedDescription'
             within('.prefecture') do
@@ -388,9 +399,19 @@ RSpec.describe "記事作成", type: :system do
           end
         end
 
+        context 'アイキャッチのXボタンをクリック' do
+          it 'アイキャッチが削除される' do
+            find('#delete-btn').click
+            expect(page).to_not have_selector("img[src$='sample.png']")
+            attach_file('アイキャッチ', 'public/images/sample.png')
+            expect(page).to have_css('#preview-eyecatch')
+            find('#delete-btn').click
+            expect(page).to_not have_css('#preview-eyecatch')
+          end
+        end
+
         context '必須項目を入力せずに保存をクリック' do
           it 'バリデーションメッセージが表示される' do
-            find('.edit-button').click
             fill_in 'タイトル', with: ' '
             fill_in 'コメント', with: ' '
             within('.prefecture') do
@@ -457,8 +478,9 @@ RSpec.describe "記事作成", type: :system do
       end
 
       context '概要欄の編集ボタンをクリック' do
+        before { find('.edit-button').click }
+
         it '概要編集フォームが表示される' do
-          find('.edit-button').click
           sleep 2
           expect(page).to have_content('タイトル')
           expect(page).to have_content('コメント')
@@ -487,7 +509,6 @@ RSpec.describe "記事作成", type: :system do
 
         context '編集して保存をクリック' do
           it '概要蘭がアップデートされる' do
-            find('.edit-button').click
             fill_in 'タイトル', with: 'UpdatedTitle'
             fill_in 'コメント', with: 'UpdatedDescription'
             within('.country') do
@@ -524,9 +545,19 @@ RSpec.describe "記事作成", type: :system do
           end
         end
 
+        context 'アイキャッチのXボタンをクリック' do
+          it 'アイキャッチが削除される' do
+            find('#delete-btn').click
+            expect(page).to_not have_selector("img[src$='sample.png']")
+            attach_file('アイキャッチ', 'public/images/sample.png')
+            expect(page).to have_css('#preview-eyecatch')
+            find('#delete-btn').click
+            expect(page).to_not have_css('#preview-eyecatch')
+          end
+        end
+
         context '必須項目を入力せずに保存をクリック' do
           it 'バリデーションメッセージが表示される' do
-            find('.edit-button').click
             fill_in 'タイトル', with: ' '
             fill_in 'コメント', with: ' '
             within('.region') do
@@ -676,6 +707,7 @@ RSpec.describe "記事作成", type: :system do
                   fill_in '価格', with: '2000'
                 end
                 fill_in 'メモ', with: 'UpdatedTestMemmo'
+                attach_file('写真', 'public/images/sample.png')
                 find('.add-button').click
                 sleep 2
               end
@@ -687,6 +719,16 @@ RSpec.describe "記事作成", type: :system do
               expect(page).to have_content('UpdatedTestTransport')
               expect(page).to have_content('1,000')
               expect(page).to have_content('2,000')
+              expect(page).to have_selector("img[src$='sample.png']")
+            end
+          end
+
+          context '写真を選択したのちXボタンをクリック' do
+            it '写真の選択が解除される' do
+              attach_file('写真', 'public/images/sample.png')
+              expect(page).to have_css('#preview-image')
+              find('#delete-btn').click
+              expect(page).to_not have_css('#preview-image')
             end
           end
 

--- a/spec/system/articles_update_destroy_spec.rb
+++ b/spec/system/articles_update_destroy_spec.rb
@@ -210,6 +210,17 @@ RSpec.describe "記事編集/削除", type: :system do
               end
             end
 
+            context 'アイキャッチのXボタンをクリック' do
+              it 'アイキャッチが削除される' do
+                find('#delete-btn').click
+                expect(page).to_not have_selector("img[src$='sample.png']")
+                attach_file('アイキャッチ', 'public/images/sample.png')
+                expect(page).to have_css('#preview-eyecatch')
+                find('#delete-btn').click
+                expect(page).to_not have_css('#preview-eyecatch')
+              end
+            end
+
             context '必須項目を入力せずに保存をクリック' do
               it 'バリデーションメッセージが表示される' do
                 fill_in 'タイトル', with: ' '
@@ -299,8 +310,9 @@ RSpec.describe "記事編集/削除", type: :system do
           end
 
           context '編集ボタンをクリック' do
+            before { find('.edit-button').click }
+
             it '概要編集フォームが表示される' do
-              find('.edit-button').click
               expect(page).to have_content('タイトル')
               expect(page).to have_content('コメント')
               expect(page).to have_content('国')
@@ -328,7 +340,6 @@ RSpec.describe "記事編集/削除", type: :system do
 
             context '編集して保存をクリック' do
               it '概要蘭がアップデートされる' do
-                find('.edit-button').click
                 fill_in 'タイトル', with: 'UpdatedTitle'
                 fill_in 'コメント', with: 'UpdatedDescription'
                 within('.country') do
@@ -365,9 +376,19 @@ RSpec.describe "記事編集/削除", type: :system do
               end
             end
 
+            context 'アイキャッチのXボタンをクリック' do
+              it 'アイキャッチが削除される' do
+                find('#delete-btn').click
+                expect(page).to_not have_selector("img[src$='sample.png']")
+                attach_file('アイキャッチ', 'public/images/sample.png')
+                expect(page).to have_css('#preview-eyecatch')
+                find('#delete-btn').click
+                expect(page).to_not have_css('#preview-eyecatch')
+              end
+            end
+
             context '必須項目を入力せずに保存をクリック' do
               it 'バリデーションメッセージが表示される' do
-                find('.edit-button').click
                 fill_in 'タイトル', with: ' '
                 fill_in 'コメント', with: ' '
                 within('.region') do
@@ -566,6 +587,7 @@ RSpec.describe "記事編集/削除", type: :system do
                   fill_in '価格', with: '2000'
                 end
                 fill_in 'メモ', with: 'UpdatedTestMemmo'
+                attach_file('写真', 'public/images/sample.png')
                 find('.add-button').click
                 sleep 2
               end
@@ -577,6 +599,16 @@ RSpec.describe "記事編集/削除", type: :system do
               expect(page).to have_content('UpdatedTestTransport')
               expect(page).to have_content('1,000')
               expect(page).to have_content('2,000')
+              expect(page).to have_selector("img[src$='sample.png']")
+            end
+          end
+
+          context '写真を選択したのちXボタンをクリック' do
+            it '写真の選択が解除される' do
+              attach_file('写真', 'public/images/sample.png')
+              expect(page).to have_css('#preview-image')
+              find('#delete-btn').click
+              expect(page).to_not have_css('#preview-image')
             end
           end
 

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -55,6 +55,16 @@ RSpec.describe 'ユーザー', type: :system do
         end
       end
 
+      context 'プロフィール画像を選択後にXボタンをクリック' do
+        it 'プロフィール画像の選択が解除される' do
+          attach_file('プロフィール画像', 'public/images/sample.png')
+          expect(page).to have_css('#preview-avatar')
+          find('.icon').click
+          expect(page).to have_css('#default-avatar')
+          expect(page).to_not have_css('#preview-image')
+        end
+      end
+
       context '何も入力せずに「登録」をクリック' do
         it 'バリデーションメッセージが表示される' do
           find('.button').click
@@ -468,6 +478,24 @@ RSpec.describe 'ユーザー', type: :system do
             fill_in 'ユーザーネーム', with: ' '
             find('.button').click
             expect(page).to have_content('ユーザーネームは必須項目です')
+          end
+        end
+
+        context 'プロフィール画像のXボタンをクリック' do
+          it 'デフォルト画像が表示される' do
+            attach_file('プロフィール画像', 'public/images/sample.png')
+            expect(page).to have_css('#preview-avatar')
+            find('.icon').click
+            expect(page).to have_css('#default-avatar')
+            expect(page).to_not have_css('#preview-avatar')
+            attach_file('プロフィール画像', 'public/images/sample.png')
+            find('.button').click
+            sleep 2
+            find('.button').click
+            expect(page).to have_selector("img[src$='sample.png']")
+            find('.icon').click
+            expect(page).to have_css('#default-avatar')
+            expect(page).to_not have_selector("img[src$='sample.png']")
           end
         end
       end


### PR DESCRIPTION
## 概要

- ユーザー登録ページ
  - プロフィール画像を選択したのちXボタンをクリックすることでプロフィール画像の選択を解除できる。
- プロフィール編集ページ
  - Xボタンをクリックすることでプロフィール画像をデフォルト画像に戻すことができる。
- 記事概要作成ページ
  - アイキャッチを選択したのちXボタンをクリックすることでアイキャッチの選択を解除できる。
- 記事詳細作成ページ/記事詳細編集ページ
  - 記事概要編集フォーム
    - Xボタンをクリックすることでアイキャッチを削除することができる。
  - ブロック作成フォーム
    - 写真を選択したのちXボタンをクリックすることで写真の選択を解除できる。
  - ブロック編集フォーム
    -  Xボタンをクリックすることで写真を削除することができる。

## 確認方法

1. ユーザー登録ページにアクセス
2. プロフィール画像を選択
3. Xボタンをクリックしてプロフィール画像の選択を解除できることを確認
4. プロフィール編集ページにアクセス
5. プロフィール画像をXボタンクリックでデフォルト画像に戻せることを確認
6. 記事概要作成ページにアクセス
7. アイキャッチを選択
8. Xボタンをクリックしてアイキャッチの選択を解除できることを確認
9. 記事詳細作成ページにアクセス
10. 記事概要編集フォームを表示
11. アイキャッチをXボタンクリックで削除できることを確認
12. ブロック作成フォームで写真を選択
13. Xボタンをクリックして写真の選択を解除できることを確認
14. ブロック編集フォームを表示
15. 写真をXボタンクリックで削除できることを確認
16. 記事詳細編集ページにアクセス
17. 記事概要編集フォームを表示
18. アイキャッチをXボタンクリックで削除できることを確認
19. ブロック作成フォームで写真を選択
20. Xボタンをクリックして写真の選択を解除できることを確認
21. ブロック編集フォームを表示
22. 写真をXボタンクリックで削除できることを確認
 
## チェックリスト

- システムスペックを追加した
- rubocopのチェックをパス
- eslintのチェックをパス