### PR TITLE
AND検索をOR検索に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,78 @@
 # Tristo
+アプリURL：https://www.tristo.work/<br>
+Qiita記事：https://qiita.com/Manabu-Ito9772/items/5e2cad71cac90dd7b654
+<br><br>
+## サービス概要
 旅行が好きな人に<br>
 旅行の記録を詳細に残せる場を提供する<br>
 旅行記録・共有サービスです。
-## Tristoについて
+### サービスをつくった背景
+私は旅行に行った際、次の旅行の参考にしたり、思い出にふけったりするために、<br>
+旅行の記録をスマホにメモしていたのですが、それをより詳細かつ体系的にまとめたいという思いから<br>
+本サービスの開発に至りました。<br>
+私のようにとにかく事細かに旅行の記録を残したいという方や、<br>
+他人の旅行記録を参考にしたいという方に、本サービスを活用して頂ければ幸いです。
 ### 登場人物
-- エンドユーザー
-  - 旅行の記録を詳細に残したい人
-  - 他人の旅行記録を参考にしたい人
-- 管理者
-  - ユーザー情報を管理する人
-  - 旅行記録を管理する人
+- 旅行の記録を詳細に残しておきたい方
+- 他人の旅行記録を参照したい方
 ### ユーザーが抱える課題
-自分が行った旅行の詳細を総合的に分かりやすくまとめたい。
+- 自分が行った旅行を詳細かつ分かりやすくまとめたい。
+- 実際に旅行に行ってきた人の情報を、自分の旅行計画の参考にしたい。
 ### 解決方法
 いつどこで何をしていくら使ったかを記録できるサービスを提供する。
 ### 望む未来
-- 過去の旅行を記録しておくことで、未来の旅行計画の参考材料にできる。
-- 他人の旅行記録を閲覧できることで、自分の旅行計画の参考材料にできる。
-### プロダクト
-旅行の記録・共有WEBサービス
+旅行の詳細情報を記録したり、他者の旅行記録を参考にしたりすることで、<br>
+旅行好きの人がより良い旅行を実現し、さらに旅行を好きになってくれることを願っています。
 ### マーケット
 20代〜40代の旅行好きな人
-### 画面遷移図
-https://xd.adobe.com/view/5efbc08b-7cec-4877-890d-2135e91ce9e7-0ba8/
-### ER図
-https://drive.google.com/file/d/1fO8xMtYBtsY0lQgfrAyN8Mmo_ozJy4AU/view?usp=sharing
+<br><br>
+## 使用技術
+### バックエンド
+- Ruby 2.6.5
+- Rails 6.1.3.1
+- RSpec 3.10.1
+#### 主要なGem
+- sorcery 0.16.0
+- jwt 2.2.2
+- active_model_serializers 0.10.12
+- kaminari 1.2.1
+- rails_admin 2.0.2
+- rspec-rails 5.0.1
+#### ER図
+[![Image from Gyazo](https://i.gyazo.com/f61a9ade003524f216f988f95969d4c2.png)](https://gyazo.com/f61a9ade003524f216f988f95969d4c2)
+### フロントエンド
+- Vue 2.6.12
+- axios 0.21.1
+- vue-router 3.5.1
+- vuex 3.6.2
+- vuex-persistedstate 4.0.0-beta.3
+- vue-mq 1.0.1
+- mobile-device-detect 0.4.3
+- vee-validate 3.4.5
+- vue-select 3.11.2
+- vue-dropdown-menu 0.1.4
+- vuejs-datepicker 1.6.2
+- vue2-timepicker 1.1.6
+- moment 2.29.1
+- vue-infinite-loading 2.4.5
+- vue-loader 15.9.6
+- vue-js-modal 2.0.0-rc.6
+- v-scroll-lock 1.3.1
+- vue-fontawesome 2.0.2
+- bootstrap 4.5.3
+<br><br>
+### インフラストラクチャー
+- Nginx 1.12.1
+- Unicorn 6.0.0
+- AWS
+  - VPC
+  - EC2
+    - Amazon Linux 2
+  - RDS
+    - MySQL 5.7.26
+  - S3
+  - ALB
+  - Route53
+  - ACM
+#### インフラ構成図
+![image](https://user-images.githubusercontent.com/72731672/117455959-a6900e00-af82-11eb-854d-a61b6e8f7621.png)

--- a/spec/system/search_articles_spec.rb
+++ b/spec/system/search_articles_spec.rb
@@ -34,15 +34,11 @@ RSpec.describe '記事検索', type: :system do
     sleep 2
   }
 
-  let(:create_article_tokyo_osaka) {
+  let(:create_article_fukuoka) {
     visit '/create_trip_note'
-    fill_in 'タイトル', with: 'Tokio_And_Osaka'
+    fill_in 'タイトル', with: 'Fukuoka'
     within('.prefecture') do
-      find('.vs__search').set('東京')
-      find('.vs__dropdown-menu').click
-    end
-    within('.prefecture') do
-      find('.vs__search').set('大阪')
+      find('.vs__search').set('福岡')
       find('.vs__dropdown-menu').click
     end
     find('.button').click
@@ -62,10 +58,6 @@ RSpec.describe '記事検索', type: :system do
       find('.vs__search').set('Tag')
       find('.vs__dropdown-menu').click
     end
-    within('.tag') do
-      find('.vs__search').set('Tag2')
-      find('.vs__dropdown-menu').click
-    end
     find('.button').click
     sleep 2
     find('.post-button').click
@@ -80,20 +72,7 @@ RSpec.describe '記事検索', type: :system do
       find('.vs__dropdown-menu').click
     end
     within('.tag') do
-      find('.vs__search').set('Tag')
-      find('.vs__dropdown-menu').click
-    end
-    find('.button').click
-    sleep 2
-    find('.post-button').click
-    sleep 2
-  }
-
-  let(:create_article_fukuoka) {
-    visit '/create_trip_note'
-    fill_in 'タイトル', with: 'Fukuoka'
-    within('.prefecture') do
-      find('.vs__search').set('福岡')
+      find('.vs__search').set('Tag2')
       find('.vs__dropdown-menu').click
     end
     find('.button').click
@@ -138,28 +117,6 @@ RSpec.describe '記事検索', type: :system do
     sleep 2
   }
 
-  let(:create_article_california_hawaii) {
-    visit '/create_trip_note'
-    find('.domestic-btn-unselected').click
-    fill_in 'タイトル', with: 'LaAloha'
-    within('.country') do
-      find('.vs__search').set('アメリカ')
-      find('.vs__dropdown-menu').click
-    end
-    within('.region') do
-      find('.vs__search').set('カリフォルニア')
-      find('.vs__dropdown-menu').click
-    end
-    within('.region') do
-      find('.vs__search').set('ハワイ')
-      find('.vs__dropdown-menu').click
-    end
-    find('.button').click
-    sleep 2
-    find('.post-button').click
-    sleep 2
-  }
-
   let(:create_article_california_with_tag) {
     visit '/create_trip_note'
     find('.domestic-btn-unselected').click
@@ -174,10 +131,6 @@ RSpec.describe '記事検索', type: :system do
     end
     within('.tag') do
       find('.vs__search').set('Tag')
-      find('.vs__dropdown-menu').click
-    end
-    within('.tag') do
-      find('.vs__search').set('Tag2')
       find('.vs__dropdown-menu').click
     end
     find('.button').click
@@ -199,7 +152,7 @@ RSpec.describe '記事検索', type: :system do
       find('.vs__dropdown-menu').click
     end
     within('.tag') do
-      find('.vs__search').set('Tag')
+      find('.vs__search').set('Tag2')
       find('.vs__dropdown-menu').click
     end
     find('.button').click
@@ -277,7 +230,8 @@ RSpec.describe '記事検索', type: :system do
       context '都道府県を複数選択して検索' do
         it '記事がある場合は表示される' do
           create_article_tokyo
-          create_article_tokyo_osaka
+          create_article_osaka
+          create_article_fukuoka
           within('#prefecture') do
             find('.vs__search').set('東京')
             find('.vs__dropdown-menu').click
@@ -288,8 +242,9 @@ RSpec.describe '記事検索', type: :system do
           end
           find('.button').click
           sleep 2
-          expect(page).to have_content('Tokio_And_Osaka')
-          expect(page).to_not have_content('Tokyo')
+          expect(page).to have_content('Tokyo')
+          expect(page).to have_content('Osaka')
+          expect(page).to_not have_content('Fukuoka')
         end
       end
 
@@ -324,6 +279,7 @@ RSpec.describe '記事検索', type: :system do
         it '記事がある場合は表示される' do
           create_article_tokyo_with_tag
           create_article_osaka_with_tag
+          create_article_fukuoka
           within('#tag') do
             find('.vs__search').set('Tag')
             find('.vs__dropdown-menu').click
@@ -335,7 +291,8 @@ RSpec.describe '記事検索', type: :system do
           find('.button').click
           sleep 2
           expect(page).to have_content('Tokyo')
-          expect(page).to_not have_content('Osaka')
+          expect(page).to have_content('Osaka')
+          expect(page).to_not have_content('Fukuoka')
         end
       end
 
@@ -364,11 +321,13 @@ RSpec.describe '記事検索', type: :system do
         it '記事がある場合は表示される' do
           create_article_tokyo
           create_article_osaka
-          fill_in 'フリーワード', with: 'a s'
+          create_article_fukuoka
+          fill_in 'フリーワード', with: 'y s'
           find('.button').click
           sleep 2
+          expect(page).to have_content('Tokyo')
           expect(page).to have_content('Osaka')
-          expect(page).to_not have_content('Tokyo')
+          expect(page).to_not have_content('Fukuoka')
         end
       end
 
@@ -522,7 +481,8 @@ RSpec.describe '記事検索', type: :system do
         context '地域を複数選択して検索' do
           it '記事がある場合は表示される' do
             create_article_california
-            create_article_california_hawaii
+            create_article_hawaii
+            create_article_paris
             within('#country') do
               find('.vs__search').set('アメリカ')
               find('.vs__dropdown-menu').click
@@ -537,8 +497,9 @@ RSpec.describe '記事検索', type: :system do
             end
             find('.button').click
             sleep 2
-            expect(page).to have_content('LaAloha')
-            expect(page).to_not have_content('California')
+            expect(page).to have_content('California')
+            expect(page).to have_content('Hawaii')
+            expect(page).to_not have_content('Paris')
           end
         end
       end
@@ -574,6 +535,7 @@ RSpec.describe '記事検索', type: :system do
         it '記事がある場合は表示される' do
           create_article_california_with_tag
           create_article_hawaii_with_tag
+          create_article_paris
           within('#tag') do
             find('.vs__search').set('Tag')
             find('.vs__dropdown-menu').click
@@ -585,7 +547,8 @@ RSpec.describe '記事検索', type: :system do
           find('.button').click
           sleep 2
           expect(page).to have_content('California')
-          expect(page).to_not have_content('Hawaii')
+          expect(page).to have_content('Hawaii')
+          expect(page).to_not have_content('Paris')
         end
       end
 
@@ -614,11 +577,13 @@ RSpec.describe '記事検索', type: :system do
         it '記事がある場合は表示される' do
           create_article_california
           create_article_hawaii
-          fill_in 'フリーワード', with: 'l f'
+          create_article_paris
+          fill_in 'フリーワード', with: 'l w'
           find('.button').click
           sleep 2
           expect(page).to have_content('California')
-          expect(page).to_not have_content('Hawaii')
+          expect(page).to have_content('Hawaii')
+          expect(page).to_not have_content('Paris')
         end
       end
 


### PR DESCRIPTION
## 概要

- 検索機能の「地域、都道府県、タグ、キーワード」での検索をAND検索からOR検索に変更。

## チェックリスト

- システムスペックを追加
- rubocopのチェックをパス
- eslintのチェックをパス