### PR TITLE
表記修正

### DIFF
--- a/app/controllers/api/blocks_controller.rb
+++ b/app/controllers/api/blocks_controller.rb
@@ -1,5 +1,5 @@
 class Api::BlocksController < ApplicationController
-  # before_action :authenticate!
+  before_action :authenticate!
   before_action :set_block, only: %i[update destroy delete_image delete_image]
   skip_before_action :verify_authenticity_token
 

--- a/app/javascript/pages/article/components/createdetail/PostButton.vue
+++ b/app/javascript/pages/article/components/createdetail/PostButton.vue
@@ -11,7 +11,7 @@
         class="m-0 p-2 w-100 text-center bg-white font-weight-bold draft-button-mobile"
         @click="saveDraft"
       >
-        非公開一覧に追加する
+        下書き保存
       </h5>
     </template>
     <template v-else>
@@ -25,7 +25,7 @@
         class="m-0 p-2 w-100 text-center bg-white font-weight-bold draft-button"
         @click="saveDraft"
       >
-        非公開一覧に追加する
+        下書き保存
       </h5>
     </template>
   </div>

--- a/app/javascript/pages/article/components/createdetail/SaveButton.vue
+++ b/app/javascript/pages/article/components/createdetail/SaveButton.vue
@@ -12,7 +12,7 @@
           class="m-0 p-2 text-center bg-white font-weight-bold draft-button-mobile"
           @click="unPublish"
         >
-          非公開にする
+          下書き状態にする
         </h5>
       </template>
       <template v-else>
@@ -26,7 +26,7 @@
           class="m-0 p-2 text-center bg-white font-weight-bold draft-button"
           @click="unPublish"
         >
-          非公開にする
+          下書き状態にする
         </h5>
       </template>
     </template>

--- a/app/javascript/pages/user/mypage.vue
+++ b/app/javascript/pages/user/mypage.vue
@@ -121,14 +121,14 @@
                       class="p-1 m-0 text-center text-muted font-weight-bold post-changer-unselect"
                       @click="showDrafts"
                     >
-                      非公開
+                      下書き
                     </h5>
                   </template>
                   <template v-else>
                     <h5
                       class="p-1 m-0 text-center text-muted font-weight-bold post-changer-unselect"
                     >
-                      非公開
+                      下書き
                     </h5>
                   </template>
                 </div>
@@ -173,7 +173,7 @@
 
                 <div class="col-4 pl-2 pr-2">
                   <h5 class="p-1 m-0 text-center text-white font-weight-bold post-changer">
-                    非公開
+                    下書き
                   </h5>
                 </div>
 
@@ -221,14 +221,14 @@
                       class="p-1 m-0 text-center text-muted font-weight-bold post-changer-unselect"
                       @click="showDrafts"
                     >
-                      非公開
+                      下書き
                     </h5>
                   </template>
                   <template v-else>
                     <h5
                       class="p-1 m-0 text-center text-muted font-weight-bold post-changer-unselect"
                     >
-                      非公開
+                      下書き
                     </h5>
                   </template>
                 </div>
@@ -280,7 +280,7 @@
                     投稿がありません
                   </template>
                   <template v-else-if="draft">
-                    非公開投稿がありません
+                    下書きがありません
                   </template>
                   <template v-else>
                     いいねした投稿がありません
@@ -417,14 +417,14 @@
                       class="p-1 m-0 text-center text-muted font-weight-bold post-changer-unselect"
                       @click="showDrafts"
                     >
-                      非公開
+                      下書き
                     </h5>
                   </template>
                   <template v-else>
                     <h5
                       class="p-1 m-0 text-center text-muted font-weight-bold post-changer-unselect"
                     >
-                      非公開
+                      下書き
                     </h5>
                   </template>
                 </div>
@@ -469,7 +469,7 @@
 
                 <div class="col-4 pl-2 pr-2">
                   <h5 class="p-1 m-0 text-center text-white font-weight-bold post-changer">
-                    非公開
+                    下書き
                   </h5>
                 </div>
 
@@ -517,14 +517,14 @@
                       class="p-1 m-0 text-center text-muted font-weight-bold post-changer-unselect"
                       @click="showDrafts"
                     >
-                      非公開
+                      下書き
                     </h5>
                   </template>
                   <template v-else>
                     <h5
                       class="p-1 m-0 text-center text-muted font-weight-bold post-changer-unselect"
                     >
-                      非公開
+                      下書き
                     </h5>
                   </template>
                 </div>
@@ -574,7 +574,7 @@
                     投稿がありません
                   </template>
                   <template v-else-if="draft">
-                    非公開投稿がありません
+                    下書きがありません
                   </template>
                   <template v-else>
                     いいねした投稿がありません

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -17,7 +17,7 @@ class Article < ApplicationRecord
 
   validates :title, presence: true, length: { maximum: 100 }
   validates :description, length: { maximum: 500 }
-  validates :map, length: { maximum: 300 }
+  validates :map, length: { maximum: 500 }
   validates :status, presence: true
   validates :eyecatch, attachment: { content_type: %r{\Aimage/(png|jpeg)\Z}, maximum: 5_242_880 }
 

--- a/spec/system/articles_create_spec.rb
+++ b/spec/system/articles_create_spec.rb
@@ -1071,14 +1071,14 @@ RSpec.describe "記事作成", type: :system do
     end
   end
 
-  describe '記事非公開投稿' do
-    it 'マイページの非公開一覧に記事が保存される（国内）' do
+  describe '記事下書き保存' do
+    it 'マイページの下書き記事一覧に記事が保存される（国内）' do
       create_article_japan
       create_block
       find('.draft-button').click
       sleep 2
       within('.post-changer') do
-        expect(page).to have_content('非公開')
+        expect(page).to have_content('下書き')
       end
       expect(page).to have_content(country_japan.articles.first.title)
       expect(page).to have_content(country_japan.articles.first.description)
@@ -1091,11 +1091,14 @@ RSpec.describe "記事作成", type: :system do
       expect(page).to have_content(user.name)
     end
 
-    it 'マイページの非公開一欄に記事が保存される（海外）' do
+    it 'マイページの下書き記事一覧に記事が保存される（海外）' do
       create_article_overseas
       create_block
       find('.draft-button').click
       sleep 2
+      within('.post-changer') do
+        expect(page).to have_content('下書き')
+      end
       expect(page).to have_content(country[1].articles.first.title)
       expect(page).to have_content(country[1].articles.first.description)
       expect(page).to have_content(country[1].name)

--- a/spec/system/articles_update_destroy_spec.rb
+++ b/spec/system/articles_update_destroy_spec.rb
@@ -804,6 +804,7 @@ RSpec.describe "記事編集/削除", type: :system do
         context '日付追加ボタンをクリック' do
           it '日付が追加される' do
             find('#add-day-button').click
+            sleep 2
             expect(page).to have_content('4日目')
           end
         end
@@ -945,7 +946,7 @@ RSpec.describe "記事編集/削除", type: :system do
 
       it '記事が非公開になりマイページに遷移' do
         within('.post-changer') do
-          expect(page).to have_content('非公開')
+          expect(page).to have_content('下書き')
         end
         expect(page).to have_content('UpdatedTitle')
         expect(page).to have_content('UpdatedDescription')
@@ -988,7 +989,7 @@ RSpec.describe "記事編集/削除", type: :system do
           find('.draft-button').click
           sleep 2
           within('.post-changer') do
-            expect(page).to have_content('非公開')
+            expect(page).to have_content('下書き')
           end
           expect(page).to have_content('UpdatedTitle')
           expect(page).to have_content('UpdatedDescription')
@@ -1097,7 +1098,7 @@ RSpec.describe "記事編集/削除", type: :system do
 
       it '記事が非公開になりマイページに遷移' do
         within('.post-changer') do
-          expect(page).to have_content('非公開')
+          expect(page).to have_content('下書き')
         end
         expect(page).to have_content('UpdatedTitle')
         expect(page).to have_content('UpdatedDescription')
@@ -1142,7 +1143,7 @@ RSpec.describe "記事編集/削除", type: :system do
           find('.draft-button').click
           sleep 2
           within('.post-changer') do
-            expect(page).to have_content('非公開')
+            expect(page).to have_content('下書き')
           end
           expect(page).to have_content('UpdatedTitle')
           expect(page).to have_content('UpdatedDescription')

--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -236,6 +236,7 @@ RSpec.describe 'コメント', type: :system do
     sleep 2
     find("#article-item-#{article_normal.id}").click
     find('.comment').click
+    sleep 2
     expect(page).to have_content(user.name)
     expect(page).to have_content('Comment')
     expect(page).to_not have_content('.fa-edit')

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe 'ユーザー', type: :system do
         expect(page).to have_content('フォロー')
         expect(page).to have_content('フォロワー')
         expect(page).to have_content('投稿')
-        expect(page).to have_content('非公開')
+        expect(page).to have_content('下書き')
         expect(page).to have_content('いいね')
       end
 
@@ -328,12 +328,12 @@ RSpec.describe 'ユーザー', type: :system do
               end
             end
 
-            context '「非公開にする」をクリック' do
+            context '「下書き状態にする」をクリック' do
               it '記事が非公開になりマイページに遷移' do
                 find('.draft-button').click
                 sleep 2
                 within('.post-changer') do
-                  expect(page).to have_content('非公開')
+                  expect(page).to have_content('下書き')
                 end
                 expect(current_path).to eq('/mypage')
                 expect(page).to have_content('TestTitle')
@@ -344,7 +344,7 @@ RSpec.describe 'ユーザー', type: :system do
         end
       end
 
-      context '「非公開」をクリック' do
+      context '「下書き」をクリック' do
         before {
           article_draft
           login_as(article_draft.user)
@@ -355,14 +355,14 @@ RSpec.describe 'ユーザー', type: :system do
           sleep 2
         }
 
-        it '自分の非公開記事一覧が表示される' do
+        it '自分の下書き記事一覧が表示される' do
           within('.post-changer') do
-            expect(page).to have_content('非公開')
+            expect(page).to have_content('下書き')
           end
           expect(page).to have_content(article_draft.title)
         end
 
-        context '自分の非公開一覧の記事をクリック' do
+        context '自分の下書き記事一覧の記事をクリック' do
           before {
             find("#article-item-#{article_draft.id}").click
             sleep 2
@@ -396,11 +396,11 @@ RSpec.describe 'ユーザー', type: :system do
             end
 
             context '「保存」をクリック' do
-              it '記事は非公開のままマイページに遷移' do
+              it '記事は下書き状態のままマイページに遷移' do
                 find('.draft-button').click
                 sleep 2
                 within('.post-changer') do
-                  expect(page).to have_content('非公開')
+                  expect(page).to have_content('下書き')
                 end
                 expect(current_path).to eq('/mypage')
                 expect(page).to have_content(article_draft.title)
@@ -526,7 +526,7 @@ RSpec.describe 'ユーザー', type: :system do
         expect(page).to have_content('フォロー')
         expect(page).to have_content('フォロワー')
         expect(page).to have_content('投稿')
-        expect(page).to have_content('非公開')
+        expect(page).to have_content('下書き')
         expect(page).to have_content('いいね')
       end
     end


### PR DESCRIPTION
## 概要

- マイページの「非公開」を「下書きに変更」
- 記事詳細作成ページの「非公開一覧に追加」を「下書き保存」に変更
- 記事編集ページの「非公開にする」を「下書き状態にする」に変更

## チェックリスト

- システムスペックをパス
- rubocopのチェックをパス
- eslintのチェックをパス