### PR TITLE
日付数/ブロック数上限設定

### DIFF
--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -1,4 +1,6 @@
 class Block < ApplicationRecord
+  MAX_BLOCKS_COUNT = 20
+
   before_save :null_to_nill
 
   has_one_attached :image
@@ -12,6 +14,7 @@ class Block < ApplicationRecord
   validates :place_info, length: { maximum: 500 }
   validates :comment, length: { maximum: 1_000 }
   validates :image, attachment: { content_type: %r{\Aimage/(png|jpeg)\Z}, maximum: 5_242_880 }
+  validate :blocks_count_must_be_within_limit
 
   def image_url
     image.attached? ? Rails.application.routes.url_helpers.rails_blob_path(image, only_path: true) : nil
@@ -23,5 +26,9 @@ class Block < ApplicationRecord
     self.title = nil if title == 'null'
     self.place_info = nil if place_info == 'null'
     self.comment = nil if comment == 'null'
+  end
+
+  def blocks_count_must_be_within_limit
+    errors.add(:base, "blocks count limit: #{MAX_BLOCKS_COUNT}") if day.blocks.count >= MAX_BLOCKS_COUNT
   end
 end

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -1,5 +1,15 @@
 class Day < ApplicationRecord
+  MAX_DAYS_COUNT = 14
+
   has_many :blocks, dependent: :destroy
   has_many :ordered_blocks, -> { order('position asc') }, class_name: :Block, dependent: :destroy
   belongs_to :article
+
+  validate :days_count_must_be_within_limit
+
+  private
+
+  def days_count_must_be_within_limit
+    errors.add(:base, "days count limit: #{MAX_DAYS_COUNT}") if article.days.count >= MAX_DAYS_COUNT
+  end
 end


### PR DESCRIPTION
## 概要

元々ビュー側では上限数以上の日付とブロックを作成できないようにしていたが、それに対応するバリデーションをモデルに設定していなかったため、DayモデルにArticleモデルと紐づくDayモデル数の上限バリデーション（14日以内）を設定、BlockモデルにDayモデルと紐づくBlockモデル数の上限バリデーション（20個以内）を設定。


## チェックリスト

- システムスペックをパス
- rubocopのチェックをパス
- eslintのチェックをパス
