### PR TITLE
JWT期限切れ時のバグ修正

### DIFF
--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -34,9 +34,7 @@ class Api::ArticlesController < ApplicationController
   end
 
   def user_favorites
-    favorites = User.find(params[:id]).favorites.includes(:article).order(created_at: :desc)
-    articles_array = Favorite.get_favorite_articles(favorites)
-    articles = Kaminari.paginate_array(articles_array).page(params[:page]).per(10)
+    articles = User.find(params[:id]).favorite_articles.published.includes(:favorites).order("favorites.created_at DESC").page(params[:page]).per(10)
     pagenation = resources_with_pagination(articles)
     articles = Article.change_to_json(articles)
     render json: { articles: articles, kaminari: pagenation }

--- a/app/javascript/store/modules/users.js
+++ b/app/javascript/store/modules/users.js
@@ -44,7 +44,12 @@ const actions = {
       .catch((err) => {
         return null
       })
-    if (!userResponse) return null
+    if (!userResponse) {
+      localStorage.removeItem('auth_token')
+      axios.defaults.headers.common['Authorization'] = ''
+      commit('setUser', null)
+      return null
+    }
 
     const authUser = userResponse.data
     if (authUser) {

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -5,14 +5,4 @@ class Favorite < ApplicationRecord
   validates :user_id, presence: true
   validates :article_id, presence: true
   validates :user_id, uniqueness: { scope: :article_id }
-
-  def self.get_favorite_articles(favorites)
-    favorite_articles = []
-
-    favorites.each do |favo|
-      favorite_articles.push(favo.article) if favo.article.status == 'published'
-    end
-
-    favorite_articles
-  end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,7 +4,7 @@ default: &default
   charset: utf8mb4
   collation: utf8mb4_general_ci
   username: root
-  password:
+  password: pineapple9772
   host: localhost
   pool: 5
   timeout: 5000


### PR DESCRIPTION
## 概要

JWT期限切れ時に記事が表示されないバグが発生したため修正。<br>
原因はJWTの期限が切れているにも関わらず`localStorage`の期限切れの`auth_token`から`current_user`を参照しようとしていることであった。<br>
JWT期限切れ時には`localStorage`の`auth_token`を削除することで、自動的に未ログインユーザーにするように設定することで解決。